### PR TITLE
CYTHINF-139 Bump CGR & GitVersioning

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.1.71",
+      "version": "3.2.31",
       "commands": ["nbgv"]
     }
   }

--- a/.github/releases/v0.2.0.md
+++ b/.github/releases/v0.2.0.md
@@ -2,3 +2,7 @@ This release includes the following:
 
 * **Package Tags**: Our NuGet packages now contain tags!
 * **Default Logger**: A default ILogger is added to the Service Collection that is preconfigured to log to standard output.  
+* **Cythral.CodeGeneration.Roslyn**: Version bump 0.9.0 - no notable changes, did this to get rid of prerelease warnings during builds.
+* **Nerdbank.GitVersioning**: Version bump 3.2.31 - fixes building the project on unsupported linux distributions and versioning differences between local and continuous integration builds.
+
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,4 +33,9 @@
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
     </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
         <PackageTags>AWS Amazon Cloud Lambda Lambdajection DependencyInjection IoC</PackageTags>
-        <CythralCodeGenerationRoslynVersion>0.8.17-alpha-g40a87e6792</CythralCodeGenerationRoslynVersion>
+        <CythralCodeGenerationRoslynVersion>0.9.0</CythralCodeGenerationRoslynVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Cythral.CodeGeneration.Roslyn.Plugin.Sdk": "0.8.17-alpha-g40a87e6792",
-    "Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk": "0.8.17-alpha-g40a87e6792"
+    "Cythral.CodeGeneration.Roslyn.Plugin.Sdk": "0.9.0",
+    "Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk": "0.9.0"
   }
 }

--- a/src/Attributes/packages.lock.json
+++ b/src/Attributes/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.1": {
       "Cythral.CodeGeneration.Roslyn.Attributes": {
         "type": "Direct",
-        "requested": "[0.8.17-alpha-g40a87e6792, )",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "Vo2ZYNAYWSfGMpcaJCiSaRf+Lf1BJsde9lMCLjePJDMRUuA+ObjizzxZKCCAk8OwGnnNxEuXC68HtISKr0VGww==",
+        "requested": "[0.9.0, )",
+        "resolved": "0.9.0",
+        "contentHash": "DHe67WQeXPmrQrAQbtrnhlRVbzYwru0P8u5s9By3eRXkJqi4uxTIX2tyR36FnDFrBIfQeSLzFT8rn8O9l/gHgQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
@@ -23,9 +23,9 @@
       },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
-        "requested": "[3.0.28, )",
-        "resolved": "3.0.28",
-        "contentHash": "pEK+I9A22tN0MgUSqupWeR5vqNHQZYFG5KSFz4q3uH8rQ3xQvGQHDuO0dAOrvSbwppWw0etReOIZ4ZzysrvdCg=="
+        "requested": "[3.2.31, )",
+        "resolved": "3.2.31",
+        "contentHash": "19grBnpqHLxViOt1cwE+cI+brQ2swdm4gfM97P+9KbbgWGfXtdy4EmpVAkUZ3MgntFYYbUvfldM4pUOmks5q0w=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
-        "requested": "[3.0.28, )",
-        "resolved": "3.0.28",
-        "contentHash": "pEK+I9A22tN0MgUSqupWeR5vqNHQZYFG5KSFz4q3uH8rQ3xQvGQHDuO0dAOrvSbwppWw0etReOIZ4ZzysrvdCg=="
+        "requested": "[3.2.31, )",
+        "resolved": "3.2.31",
+        "contentHash": "19grBnpqHLxViOt1cwE+cI+brQ2swdm4gfM97P+9KbbgWGfXtdy4EmpVAkUZ3MgntFYYbUvfldM4pUOmks5q0w=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <Import Project="../Directory.Build.props" />
     
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="all" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,0 @@
- <Project>
-    <Import Project="../Directory.Build.props" />
-    
-    <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    </ItemGroup>
-</Project>

--- a/src/Generator/packages.lock.json
+++ b/src/Generator/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETCoreApp,Version=v3.1": {
       "Cythral.CodeGeneration.Roslyn": {
         "type": "Direct",
-        "requested": "[0.8.17-alpha-g40a87e6792, )",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "pwtQpu0QyOZ5YhhAHfgLFkGN1SFvH0P8nucGUUbpxZV8eZj+j55fuMVgdIgsaZ2frQU4ct2d0vGoWUnhXaAG7w==",
+        "requested": "[0.9.0, )",
+        "resolved": "0.9.0",
+        "contentHash": "whskLGj2Z1Q/Ia/PV4myGac+lCZbc+jqeXfwOOG0SWfNG6VKWt/Re4b2h+bEVx6iDxV7SmfRfV+iZ9YIR31XdQ==",
         "dependencies": {
-          "Cythral.CodeGeneration.Roslyn.Attributes": "0.8.17-alpha-g40a87e6792",
+          "Cythral.CodeGeneration.Roslyn.Attributes": "0.9.0",
           "Microsoft.CodeAnalysis.CSharp": "[3.4.0]"
         }
       },
@@ -24,14 +24,14 @@
       },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
-        "requested": "[3.0.28, )",
-        "resolved": "3.0.28",
-        "contentHash": "pEK+I9A22tN0MgUSqupWeR5vqNHQZYFG5KSFz4q3uH8rQ3xQvGQHDuO0dAOrvSbwppWw0etReOIZ4ZzysrvdCg=="
+        "requested": "[3.2.31, )",
+        "resolved": "3.2.31",
+        "contentHash": "19grBnpqHLxViOt1cwE+cI+brQ2swdm4gfM97P+9KbbgWGfXtdy4EmpVAkUZ3MgntFYYbUvfldM4pUOmks5q0w=="
       },
       "Cythral.CodeGeneration.Roslyn.Attributes": {
         "type": "Transitive",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "Vo2ZYNAYWSfGMpcaJCiSaRf+Lf1BJsde9lMCLjePJDMRUuA+ObjizzxZKCCAk8OwGnnNxEuXC68HtISKr0VGww==",
+        "resolved": "0.9.0",
+        "contentHash": "DHe67WQeXPmrQrAQbtrnhlRVbzYwru0P8u5s9By3eRXkJqi4uxTIX2tyR36FnDFrBIfQeSLzFT8rn8O9l/gHgQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
@@ -998,7 +998,7 @@
       "Lambdajection.Attributes": {
         "type": "Project",
         "dependencies": {
-          "Cythral.CodeGeneration.Roslyn.Attributes": "0.8.17-alpha-g40a87e6792"
+          "Cythral.CodeGeneration.Roslyn.Attributes": "0.9.0"
         }
       }
     }

--- a/src/Metapackage/packages.lock.json
+++ b/src/Metapackage/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.1": {
       "Cythral.CodeGeneration.Roslyn.Tool": {
         "type": "Direct",
-        "requested": "[0.8.17-alpha-g40a87e6792, )",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "gD8ZXGSGvGZike8FB4TB6ELhi20i8zzbMwQTCO+ejAbY7yH4E+0xLACXcQClJysQFvVo2AHUHqgsqkNH/6TvCQ=="
+        "requested": "[0.9.0, )",
+        "resolved": "0.9.0",
+        "contentHash": "mxX4rQklQpNEPsheTYMpXtpb038smVOaj1BeROidJXdJC5Dhn0ne8K1MNZLkj37rch6+vx0Xs0aZJXskO+pXFw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -20,9 +20,9 @@
       },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
-        "requested": "[3.0.28, )",
-        "resolved": "3.0.28",
-        "contentHash": "pEK+I9A22tN0MgUSqupWeR5vqNHQZYFG5KSFz4q3uH8rQ3xQvGQHDuO0dAOrvSbwppWw0etReOIZ4ZzysrvdCg=="
+        "requested": "[3.2.31, )",
+        "resolved": "3.2.31",
+        "contentHash": "19grBnpqHLxViOt1cwE+cI+brQ2swdm4gfM97P+9KbbgWGfXtdy4EmpVAkUZ3MgntFYYbUvfldM4pUOmks5q0w=="
       },
       "Amazon.Lambda.Core": {
         "type": "Transitive",
@@ -31,8 +31,8 @@
       },
       "Cythral.CodeGeneration.Roslyn.Attributes": {
         "type": "Transitive",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "Vo2ZYNAYWSfGMpcaJCiSaRf+Lf1BJsde9lMCLjePJDMRUuA+ObjizzxZKCCAk8OwGnnNxEuXC68HtISKr0VGww==",
+        "resolved": "0.9.0",
+        "contentHash": "DHe67WQeXPmrQrAQbtrnhlRVbzYwru0P8u5s9By3eRXkJqi4uxTIX2tyR36FnDFrBIfQeSLzFT8rn8O9l/gHgQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
@@ -1079,7 +1079,7 @@
       "Lambdajection.Attributes": {
         "type": "Project",
         "dependencies": {
-          "Cythral.CodeGeneration.Roslyn.Attributes": "0.8.17-alpha-g40a87e6792"
+          "Cythral.CodeGeneration.Roslyn.Attributes": "0.9.0"
         }
       },
       "Lambdajection.Core": {

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -27,6 +27,22 @@
           "Microsoft.TestPlatform.TestHost": "16.4.0"
         }
       },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "aZyGyGg2nFSxix+xMkPmlmZSsnGQ3w+mIG23LTxJZHN+GPwTQ5FpPgDo7RMOq+Kcf5D4hFWfXkGhoGstawX13Q==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.0.0",
+          "Microsoft.SourceLink.Common": "1.0.0"
+        }
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.2.31, )",
+        "resolved": "3.2.31",
+        "contentHash": "19grBnpqHLxViOt1cwE+cI+brQ2swdm4gfM97P+9KbbgWGfXtdy4EmpVAkUZ3MgntFYYbUvfldM4pUOmks5q0w=="
+      },
       "NSubstitute": {
         "type": "Direct",
         "requested": "[4.2.2, )",
@@ -101,6 +117,11 @@
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -263,6 +284,11 @@
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "Cythral.CodeGeneration.Roslyn.Tool": {
         "type": "Direct",
-        "requested": "[0.8.17-alpha-g40a87e6792, )",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "gD8ZXGSGvGZike8FB4TB6ELhi20i8zzbMwQTCO+ejAbY7yH4E+0xLACXcQClJysQFvVo2AHUHqgsqkNH/6TvCQ=="
+        "requested": "[0.9.0, )",
+        "resolved": "0.9.0",
+        "contentHash": "mxX4rQklQpNEPsheTYMpXtpb038smVOaj1BeROidJXdJC5Dhn0ne8K1MNZLkj37rch6+vx0Xs0aZJXskO+pXFw=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -87,17 +87,17 @@
       },
       "Cythral.CodeGeneration.Roslyn": {
         "type": "Transitive",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "pwtQpu0QyOZ5YhhAHfgLFkGN1SFvH0P8nucGUUbpxZV8eZj+j55fuMVgdIgsaZ2frQU4ct2d0vGoWUnhXaAG7w==",
+        "resolved": "0.9.0",
+        "contentHash": "whskLGj2Z1Q/Ia/PV4myGac+lCZbc+jqeXfwOOG0SWfNG6VKWt/Re4b2h+bEVx6iDxV7SmfRfV+iZ9YIR31XdQ==",
         "dependencies": {
-          "Cythral.CodeGeneration.Roslyn.Attributes": "0.8.17-alpha-g40a87e6792",
+          "Cythral.CodeGeneration.Roslyn.Attributes": "0.9.0",
           "Microsoft.CodeAnalysis.CSharp": "[3.4.0]"
         }
       },
       "Cythral.CodeGeneration.Roslyn.Attributes": {
         "type": "Transitive",
-        "resolved": "0.8.17-alpha-g40a87e6792",
-        "contentHash": "Vo2ZYNAYWSfGMpcaJCiSaRf+Lf1BJsde9lMCLjePJDMRUuA+ObjizzxZKCCAk8OwGnnNxEuXC68HtISKr0VGww==",
+        "resolved": "0.9.0",
+        "contentHash": "DHe67WQeXPmrQrAQbtrnhlRVbzYwru0P8u5s9By3eRXkJqi4uxTIX2tyR36FnDFrBIfQeSLzFT8rn8O9l/gHgQ==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
@@ -1002,7 +1002,7 @@
       "Lambdajection.Attributes": {
         "type": "Project",
         "dependencies": {
-          "Cythral.CodeGeneration.Roslyn.Attributes": "0.8.17-alpha-g40a87e6792"
+          "Cythral.CodeGeneration.Roslyn.Attributes": "0.9.0"
         }
       },
       "Lambdajection.Core": {
@@ -1018,7 +1018,7 @@
       "Lambdajection.Generator": {
         "type": "Project",
         "dependencies": {
-          "Cythral.CodeGeneration.Roslyn": "0.8.17-alpha-g40a87e6792",
+          "Cythral.CodeGeneration.Roslyn": "0.9.0",
           "Lambdajection.Attributes": "1.0.0"
         }
       }


### PR DESCRIPTION
- Bumped Cythral.CodeGeneration.Roslyn to v0.9.0 to get rid of build warnings around using prerelease versions
- Bumped GitVersioning to v3.2.31 to get builds working on unsupported linux distros (mainly ArchLinux haha)
- Consolidated Directory.Build.props files - since GitVersioning works on linux now, don't need to restrict this to just the projects in the src folder. 