### PR TITLE
CYTHINF-148 Error Diagnostics

### DIFF
--- a/.github/releases/v0.2.1.md
+++ b/.github/releases/v0.2.1.md
@@ -2,3 +2,4 @@ This release includes the following:
 
 - Minor refactor of the LambdaHost class, splitting out static data initialization into a new class, LambdaHostBuilder.
 - Introduces the usage of FxCop Analyzers in this project, and a few changes to comply to the ruleset.
+- Uses Roslyn Diagnostics to report errors rather than throwing an exception.


### PR DESCRIPTION
Now using Roslyn Diagnostics to report errors instead of throwing an exception.  The latter would lead to cryptic error messages. 