### PR TITLE
LAMBJ-5 LambdaHost and LambdaHostBuilder Aliases

### DIFF
--- a/tests/WithFactories/Core/LambdaHostBuilderTests.cs
+++ b/tests/WithFactories/Core/LambdaHostBuilderTests.cs
@@ -14,6 +14,22 @@ using NSubstitute;
 
 using NUnit.Framework;
 
+using TestLambdaHost = Lambdajection.Core.LambdaHost<
+    Lambdajection.TestLambda,
+    object,
+    object,
+    Lambdajection.TestStartup,
+    Lambdajection.TestConfigurator
+>;
+
+using TestLambdaHostBuilder = Lambdajection.Core.LambdaHostBuilder<
+    Lambdajection.TestLambda,
+    object,
+    object,
+    Lambdajection.TestStartup,
+    Lambdajection.TestConfigurator
+>;
+
 namespace Lambdajection.Core.Tests
 {
     public class LambdaHostBuilderTests
@@ -21,22 +37,22 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void BuildSetsTheServiceProvider()
         {
-            var host = new LambdaHost<TestLambda, object, object, TestStartup, TestConfigurator>(lambdaHost => { });
+            var host = new TestLambdaHost(lambdaHost => { });
             host.ServiceProvider.Should().BeNull();
 
-            LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.Build(host);
+            TestLambdaHostBuilder.Build(host);
             host.ServiceProvider.Should().NotBeNull();
         }
 
         [Test]
         public void BuildSetsTheServiceProviderIfItAlreadyWasBuilt()
         {
-            var host = new LambdaHost<TestLambda, object, object, TestStartup, TestConfigurator>(lambdaHost => { });
+            var host = new TestLambdaHost(lambdaHost => { });
             host.ServiceProvider.Should().BeNull();
 
             var serviceProvider = Substitute.For<IServiceProvider>();
-            LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.serviceProvider = serviceProvider;
-            LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.Build(host);
+            TestLambdaHostBuilder.serviceProvider = serviceProvider;
+            TestLambdaHostBuilder.Build(host);
 
             host.ServiceProvider.Should().BeSameAs(serviceProvider);
         }
@@ -44,7 +60,7 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void BuildServiceProviderReturnsServiceProviderWithConfiguration()
         {
-            var provider = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildServiceProvider();
+            var provider = TestLambdaHostBuilder.BuildServiceProvider();
 
             var configuration = provider.GetService<IConfiguration>();
             configuration.Should().NotBeNull();
@@ -53,7 +69,7 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void BuildServiceProviderReturnsServiceProviderWithLogger()
         {
-            var provider = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildServiceProvider();
+            var provider = TestLambdaHostBuilder.BuildServiceProvider();
 
             var configuration = provider.GetService<ILogger<TestLambda>>();
             configuration.Should().NotBeNull();
@@ -62,7 +78,7 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void BuildServiceProviderReturnsServiceProviderWithLambda()
         {
-            var provider = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildServiceProvider();
+            var provider = TestLambdaHostBuilder.BuildServiceProvider();
 
             var configuration = provider.GetService<TestLambda>();
             configuration.Should().NotBeNull();
@@ -71,7 +87,7 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void BuildConfigurationShouldAddJsonFile()
         {
-            var configuration = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildConfiguration();
+            var configuration = TestLambdaHostBuilder.BuildConfiguration();
 
             configuration.Providers.Should().Contain(provider => provider.GetType() == typeof(JsonConfigurationProvider));
         }
@@ -79,7 +95,7 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void JsonConfigurationShouldBeOptional()
         {
-            var configuration = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildConfiguration();
+            var configuration = TestLambdaHostBuilder.BuildConfiguration();
             var providerQuery = from p in configuration.Providers where p.GetType() == typeof(JsonConfigurationProvider) select (JsonConfigurationProvider)p;
             var provider = providerQuery.First();
 
@@ -89,7 +105,7 @@ namespace Lambdajection.Core.Tests
         [Test]
         public void BuildConfigurationShouldAddEnvironmentVariables()
         {
-            var configuration = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildConfiguration();
+            var configuration = TestLambdaHostBuilder.BuildConfiguration();
             configuration.Providers.Should().Contain(provider => provider.GetType() == typeof(EnvironmentVariablesConfigurationProvider));
         }
 
@@ -97,7 +113,7 @@ namespace Lambdajection.Core.Tests
         public void BuildServiceCollectionShouldAddConfiguration()
         {
             var configuration = Substitute.For<IConfigurationRoot>();
-            var collection = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildServiceCollection(configuration);
+            var collection = TestLambdaHostBuilder.BuildServiceCollection(configuration);
 
             collection.Should().Contain(descriptor =>
                 descriptor.ServiceType == typeof(IConfiguration) &&
@@ -110,7 +126,7 @@ namespace Lambdajection.Core.Tests
         public void BuildServiceCollectionShouldAddLambda()
         {
             var configuration = Substitute.For<IConfigurationRoot>();
-            var collection = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildServiceCollection(configuration);
+            var collection = TestLambdaHostBuilder.BuildServiceCollection(configuration);
 
             collection.Should().Contain(descriptor =>
                 descriptor.ServiceType == typeof(TestLambda) &&
@@ -123,7 +139,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var serviceCollection = Substitute.For<IServiceCollection>();
-            var configurator = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildOptionsConfigurator(configuration, serviceCollection);
+            var configurator = TestLambdaHostBuilder.BuildOptionsConfigurator(configuration, serviceCollection);
 
             configurator.Configuration.Should().BeSameAs(configuration);
             configurator.ServicesSetByConfigureOptions.Should().BeSameAs(serviceCollection);
@@ -134,7 +150,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var serviceCollection = Substitute.For<IServiceCollection>();
-            var configurator = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildOptionsConfigurator(configuration, serviceCollection);
+            var configurator = TestLambdaHostBuilder.BuildOptionsConfigurator(configuration, serviceCollection);
 
             configurator.ServicesSetByConfigureAwsServices.Should().BeSameAs(serviceCollection);
         }
@@ -144,7 +160,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var collection = Substitute.For<IServiceCollection>();
-            var startup = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildLambdaStartup(configuration, collection);
+            var startup = TestLambdaHostBuilder.BuildLambdaStartup(configuration, collection);
 
             startup.Configuration.Should().BeSameAs(configuration);
         }
@@ -154,7 +170,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var collection = Substitute.For<IServiceCollection>();
-            var startup = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildLambdaStartup(configuration, collection);
+            var startup = TestLambdaHostBuilder.BuildLambdaStartup(configuration, collection);
 
             startup.Services.Should().BeSameAs(collection);
         }
@@ -164,7 +180,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var collection = new ServiceCollection();
-            var startup = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildLambdaStartup(configuration, collection);
+            var startup = TestLambdaHostBuilder.BuildLambdaStartup(configuration, collection);
 
             collection.Should().Contain(descriptor => descriptor.ServiceType == typeof(ILoggerFactory));
         }
@@ -174,7 +190,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var collection = new ServiceCollection();
-            var startup = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildLambdaStartup(configuration, collection);
+            var startup = TestLambdaHostBuilder.BuildLambdaStartup(configuration, collection);
 
             collection.Should().Contain(descriptor => descriptor.ImplementationType == typeof(ConsoleLoggerProvider));
         }
@@ -184,7 +200,7 @@ namespace Lambdajection.Core.Tests
         {
             var configuration = Substitute.For<IConfigurationRoot>();
             var collection = new ServiceCollection();
-            var startup = LambdaHostBuilder<TestLambda, object, object, TestStartup, TestConfigurator>.BuildLambdaStartup(configuration, collection);
+            var startup = TestLambdaHostBuilder.BuildLambdaStartup(configuration, collection);
 
             startup.LoggingBuilder.Should().NotBeNull();
         }

--- a/tests/WithFactories/Core/LambdaHostTests.cs
+++ b/tests/WithFactories/Core/LambdaHostTests.cs
@@ -10,6 +10,14 @@ using NSubstitute;
 
 using NUnit.Framework;
 
+using TestLambdaHost = Lambdajection.Core.LambdaHost<
+    Lambdajection.TestLambda,
+    object,
+    object,
+    Lambdajection.TestStartup,
+    Lambdajection.TestConfigurator
+>;
+
 namespace Lambdajection.Core.Tests
 {
     public class LambdaHostTests
@@ -22,10 +30,10 @@ namespace Lambdajection.Core.Tests
             lambda.Handle(Arg.Any<object>(), Arg.Any<ILambdaContext>()).Returns(expectedResponse);
 
             var collection = new ServiceCollection();
-            collection.AddSingleton<TestLambda>(lambda);
+            collection.AddSingleton(lambda);
 
             var provider = collection.BuildServiceProvider();
-            var host = new LambdaHost<TestLambda, object, object, TestStartup, TestConfigurator>(lambdaHost =>
+            var host = new TestLambdaHost(lambdaHost =>
             {
                 lambdaHost.ServiceProvider = provider;
             });


### PR DESCRIPTION
Cleaning up tests by aliasing the long generic names for LambdaHost<> and LambdaHostBuilder<>