### PR TITLE
LAMBJ-25 Startup Constructor DI

### DIFF
--- a/.github/releases/v0.3.0-beta2.md
+++ b/.github/releases/v0.3.0-beta2.md
@@ -7,6 +7,8 @@ This release introduces the following:
 - NuGet Package Version Badges in the README! Easily check the latest version of each package right from the Lambdajection repository.
 - Documentation comments have been added to public facing APIs. Use Omnisharp/Intellisense to take full advantage of this.
 - Examples for adding/using AWS Client Factories and Encrypted Options have been added and linked to in the README.
+- **Breaking Change**: Startup classes are now added to the service collection and use constructor DI to inject the IConfiguration object (this matches the approach that ASP.NET Core uses). The Configuration property on ILambdaStartup has been removed and is no longer set during lambda startup.
+- **Breaking Change**: The LambdaHost constructor allowing a custom builder function/action has been marked as internal, as this was only intended for internal testing purposes.
 
 See the Encrypted Options example for usage of Lambda.Encryption:
 https://github.com/cythral/lambdajection/tree/v0.3.0-beta2/examples/EncryptedOptions

--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ namespace Your.Namespace
 {
     public class Startup : ILambdaStartup
     {
-        public IConfiguration Configuration { get; set; } = default!;
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/examples/AwsClientFactories/Startup.cs
+++ b/examples/AwsClientFactories/Startup.cs
@@ -9,7 +9,12 @@ namespace Lambdajection.Examples.AwsClientFactories
 {
     public class Startup : ILambdaStartup
     {
-        public IConfiguration Configuration { get; set; } = null!;
+        public IConfiguration Configuration { get; }
+        
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/examples/AwsClientFactories/cloudformation.template.yml
+++ b/examples/AwsClientFactories/cloudformation.template.yml
@@ -6,7 +6,7 @@ Resources:
       Handler: AwsClientFactories::Lambdajection.Examples.AwsClientFactories.Handler::Run
       Runtime: dotnetcore3.1
       Timeout: 300
-      CodeUri: ../../bin/AwsClientFactories/Release/netcoreapp3.1/publish/
+      CodeUri: ../../bin/Examples/AwsClientFactories/Release/netcoreapp3.1/publish/
       MemorySize: 512
       Policies:
         - AWSLambdaExecute

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -3,7 +3,7 @@
         <OutputPath>$(MSBuildThisFileDirectory)..\bin\Examples\$(MSBuildProjectName)\$(Configuration)</OutputPath>
         <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\Examples\$(MSBuildProjectName)</BaseIntermediateOutputPath>
         <PackageOutputPath>$(MSBuildThisFileDirectory)..\bin\Packages\Examples\$(Configuration)</PackageOutputPath>
-        <RestorePackagesPath>$(MSBuildThisFileDirectory)..\.nuget</RestorePackagesPath>
+        <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
         <_PackagesDebug>$(MSBuildThisFileDirectory)..\bin\Packages\Debug</_PackagesDebug>
         <_PackagesRelease>$(MSBuildThisFileDirectory)..\bin\Packages\Release</_PackagesRelease>
         <RestoreAdditionalProjectSources>@(CustomLocalFeed);$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>

--- a/examples/EncryptedOptions/Startup.cs
+++ b/examples/EncryptedOptions/Startup.cs
@@ -7,7 +7,12 @@ namespace Lambdajection.Examples.EncryptedOptions
 {
     public class Startup : ILambdaStartup
     {
-        public IConfiguration Configuration { get; set; }
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/examples/EncryptedOptions/cloudformation.template.yml
+++ b/examples/EncryptedOptions/cloudformation.template.yml
@@ -6,7 +6,7 @@ Resources:
       Handler: EncryptedOptions::Lambdajection.Examples.EncryptedOptions.Handler::Run
       Runtime: dotnetcore3.1
       Timeout: 300
-      CodeUri: ../bin/EncryptedOptions/Release/netcoreapp3.1/publish/
+      CodeUri: ../../bin/Examples/EncryptedOptions/Release/netcoreapp3.1/publish/
       MemorySize: 512
       Policies:
         - AWSLambdaExecute

--- a/src/Core/ILambdaStartup.cs
+++ b/src/Core/ILambdaStartup.cs
@@ -1,5 +1,3 @@
-
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -11,9 +9,6 @@ namespace Lambdajection.Core
     /// </summary>
     public interface ILambdaStartup
     {
-        /// <value>The configuration used for the lambda.</value>
-        IConfiguration Configuration { get; set; }
-
         /// <summary>
         /// Configures services to be injected into the lambda's IoC container.
         /// </summary>

--- a/src/Core/LambdaHost.cs
+++ b/src/Core/LambdaHost.cs
@@ -17,8 +17,8 @@ namespace Lambdajection.Core
     /// <typeparam name="TLambdaConfigurator">The type to use for the lambda configurator (sets up options and aws services).</typeparam>
     public class LambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator>
         where TLambda : class, ILambda<TLambdaParameter, TLambdaOutput>
-        where TLambdaStartup : ILambdaStartup, new()
-        where TLambdaConfigurator : ILambdaConfigurator, new()
+        where TLambdaStartup : class, ILambdaStartup
+        where TLambdaConfigurator : class, ILambdaConfigurator
     {
 
         /// <value>Provides services to the lambda.</value>
@@ -35,7 +35,7 @@ namespace Lambdajection.Core
         /// Constructs a new Lambda Host / IoC Container with the given host builder function.
         /// </summary>
         /// <param name="build"></param>
-        public LambdaHost(Action<LambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator>> build)
+        internal LambdaHost(Action<LambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator>> build)
         {
             build(this);
         }

--- a/src/ExamplesTool/ExamplesTool.csproj
+++ b/src/ExamplesTool/ExamplesTool.csproj
@@ -18,7 +18,7 @@
 
         <MSBuild 
             Projects="@(_Examples)"
-            Targets="Clean;Restore;Build"
+            Targets="Clean;Restore;Build;Publish"
             Properties="LambdajectionVersion=$(PackageVersion);Configuration=$(Configuration);Architecture=$(Architecture)"
         />
     </Target>

--- a/tests/WithFactories/ConfigurationIntegrationTests.cs
+++ b/tests/WithFactories/ConfigurationIntegrationTests.cs
@@ -39,7 +39,12 @@ namespace Lambdajection.Tests.Configuration
     public class Startup : ILambdaStartup
     {
         public static IDecryptionService DecryptionService { get; } = Substitute.For<IDecryptionService>();
-        public IConfiguration Configuration { get; set; } = null!;
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/tests/WithFactories/IntegrationTests.cs
+++ b/tests/WithFactories/IntegrationTests.cs
@@ -60,7 +60,12 @@ namespace Lambdajection.Tests
 
     public class Startup : ILambdaStartup
     {
-        public IConfiguration Configuration { get; set; } = default!;
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
         public void ConfigureServices(IServiceCollection collection)
         {

--- a/tests/WithoutFactories/IntegrationTests.cs
+++ b/tests/WithoutFactories/IntegrationTests.cs
@@ -32,7 +32,12 @@ namespace Lambdajection.TestsWithoutFactories
 
     public class Startup : ILambdaStartup
     {
-        public IConfiguration Configuration { get; set; } = default!;
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
         public void ConfigureServices(IServiceCollection collection)
         {


### PR DESCRIPTION
Introduces 2 new breaking changes. 

- Startup classes are now added to the service collection and use constructor DI to inject the IConfiguration object (this matches the approach that ASP.NET Core uses). The Configuration property on ILambdaStartup has been removed and is no longer set during lambda startup.
- The LambdaHost constructor allowing a custom builder function/action has been marked as internal, as this was only intended for internal testing purposes.