### PR TITLE
LAMBJ-37 v0.3.0-beta3

### DIFF
--- a/.github/releases/v0.3.0-beta3.md
+++ b/.github/releases/v0.3.0-beta3.md
@@ -1,0 +1,1 @@
+This release introduces the following:

--- a/.github/releases/v0.3.0-beta3.md
+++ b/.github/releases/v0.3.0-beta3.md
@@ -1,1 +1,3 @@
 This release introduces the following:
+
+- Fixes an issue where client factories would attempt to do an sts:AssumeRole if no role arn was given.

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -373,7 +373,7 @@ namespace Lambdajection.Generator
 
                 IEnumerable<StatementSyntax> GenerateBody()
                 {
-                    yield return IfStatement(ParseExpression("roleArn == null"),
+                    yield return IfStatement(ParseExpression("roleArn != null"),
                         Block(
                             ParseStatement("var request = new AssumeRoleRequest { RoleArn = roleArn, RoleSessionName = \"lambdajection-assume-role\" };"),
                             ParseStatement("var response = await stsClient.AssumeRoleAsync(request);"),

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.3.0-beta2",
+  "version": "0.3.0-beta3",
   "publicReleaseRefSpec": ["^refs/heads/master$", "^refs/tags/v\\d\\.\\d"]
 }


### PR DESCRIPTION
## Release Notes

This release introduces the following:

- Fixes an issue where client factories would attempt to do an sts:AssumeRole if no role arn was given.

<h2>        Stories
</h2>
<ul>
<li>[<a href='https://cythral.atlassian.net/browse/LAMBJ-36'>LAMBJ-36</a>] -         AWS Factories Invalid RoleArn Condition
</li>
</ul>