### PR TITLE
LAMBJ-36 Client Factories RoleArn Fix

### DIFF
--- a/.github/releases/v0.3.0-beta3.md
+++ b/.github/releases/v0.3.0-beta3.md
@@ -1,1 +1,3 @@
 This release introduces the following:
+
+- Fixes an issue where client factories would attempt to do an sts:AssumeRole if no role arn was given.

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -373,7 +373,7 @@ namespace Lambdajection.Generator
 
                 IEnumerable<StatementSyntax> GenerateBody()
                 {
-                    yield return IfStatement(ParseExpression("roleArn == null"),
+                    yield return IfStatement(ParseExpression("roleArn != null"),
                         Block(
                             ParseStatement("var request = new AssumeRoleRequest { RoleArn = roleArn, RoleSessionName = \"lambdajection-assume-role\" };"),
                             ParseStatement("var response = await stsClient.AssumeRoleAsync(request);"),


### PR DESCRIPTION
Fixes an issue where client factories would attempt to do an sts:AssumeRole if no role arn was given. 