### PR TITLE
LAMBJ-29 Static Service Provider Initialization

### DIFF
--- a/.github/releases/v0.3.0.md
+++ b/.github/releases/v0.3.0.md
@@ -1,3 +1,4 @@
 This release introduces the following:
 
 - We now run end to end tests before each release. This takes the form of deploying our examples to an AWS account, invoking them and checking the output for correctness.
+- Lambda service providers are now initialized at their declaration, rather than inside the LambdaHostBuilder.Build method. This leads to faster (albeit slight) startup times due to the fact that the field does not get initialized to null once then be reassigned later during runtime.

--- a/src/Core/LambdaHostBuilder.cs
+++ b/src/Core/LambdaHostBuilder.cs
@@ -12,11 +12,10 @@ namespace Lambdajection.Core
         where TLambdaStartup : class, ILambdaStartup
         where TLambdaConfigurator : class, ILambdaConfigurator
     {
-        internal static IServiceProvider? serviceProvider;
+        internal static IServiceProvider serviceProvider = BuildServiceProvider();
 
         public static void Build(LambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator> host)
         {
-            serviceProvider ??= BuildServiceProvider();
             host.ServiceProvider = serviceProvider;
         }
 


### PR DESCRIPTION
Lambda service providers are now initialized at their declaration, rather than inside the LambdaHostBuilder.Build method. This leads to faster (albeit slight) startup times due to the fact that the field does not get initialized to null once then be reassigned later during runtime.