### PR TITLE
LAMBJ-11 Startup Constructor Argument

### DIFF
--- a/.github/releases/v0.4.0-beta1.md
+++ b/.github/releases/v0.4.0-beta1.md
@@ -1,3 +1,4 @@
 This release introduces the following:
 
 - You can now control the serializer used on the Lambda by setting the Serializer argument in the Lambda attribute.  If your Lambda targets netcoreapp3.1, then DefaultLambdaJsonSerializer from Amazon.Lambda.Serialization.SystemTextJson is used by default.
+- The startup argument in the Lambda attribute is now a constructor argument, rather than a named one.  This was done to enforce setting the argument earlier in the pipeline, rather than just failing during code generation.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ using Lambdajection.Attributes;
 
 namespace Your.Namespace
 {
-    [Lambda(Startup = typeof(Startup))]
+    [Lambda(typeof(Startup))]
     public partial class YourLambda
     {
         private IRegisteredService yourService;
@@ -110,7 +110,7 @@ namespace Your.Namespace
 If your Lambda targets the `netcoreapp3.1` framework, then by default, the serializer is set to  `DefaultLambdaJsonSerializer` from the `Amazon.Lambda.Serialization.SystemTextJson` package.  With any TFM, you may specify the serializer you want to use by setting the Lambda attribute's `Serializer` argument:
 
 ```cs
-[Lambda(Startup = typeof(Startup), Serializer = typeof(Serializer))]
+[Lambda(typeof(Startup), Serializer = typeof(Serializer))]
 public partial class Lambda
 {
     ...

--- a/examples/AwsClientFactories/Handler.cs
+++ b/examples/AwsClientFactories/Handler.cs
@@ -9,7 +9,7 @@ using Lambdajection.Core;
 
 namespace Lambdajection.Examples.AwsClientFactories
 {
-    [Lambda(Startup = typeof(Startup))]
+    [Lambda(typeof(Startup))]
     public partial class Handler
     {
         private readonly IAwsFactory<IAmazonS3> s3Factory;

--- a/examples/EncryptedOptions/Handler.cs
+++ b/examples/EncryptedOptions/Handler.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Lambdajection.Examples.EncryptedOptions
 {
-    [Lambda(Startup = typeof(Startup))]
+    [Lambda(typeof(Startup))]
     public partial class Handler
     {
         private readonly Options options;

--- a/src/Attributes/LambdaAttribute.cs
+++ b/src/Attributes/LambdaAttribute.cs
@@ -14,8 +14,17 @@ namespace Lambdajection.Attributes
     [Conditional("CodeGeneration")]
     public class LambdaAttribute : Attribute
     {
+        /// <summary>
+        /// Constructs a new LambdaAttribute.
+        /// </summary>
+        /// <param name="startup">The type of startup class to use for the lambda.</param>
+        public LambdaAttribute(Type startup)
+        {
+            this.Startup = startup;
+        }
+
         /// <value>The type of Startup class to use for the Lambda.  The type passed must implement <c>ILambdaStartup</c>.</value>
-        public Type Startup { get; set; } = null!;
+        public Type Startup { get; } = null!;
 
         /// <value>The type of Serializer to use for the Lambda.</value>
         public Type Serializer { get; set; } = null!;

--- a/src/Core/Properties.cs
+++ b/src/Core/Properties.cs
@@ -1,4 +1,3 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Lambdajection.Tests")]
-[assembly: InternalsVisibleTo("Lambdajection.Tests")]

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -50,6 +50,11 @@ namespace Lambdajection.Generator
 
         private static INamedTypeSymbol? GetAttributeArgument(AttributeData attributeData, string argName)
         {
+            if (argName == "Startup")
+            {
+                return (INamedTypeSymbol?)attributeData.ConstructorArguments[0].Value;
+            }
+
             var query = from arg in attributeData.NamedArguments
                         where arg.Key == argName
                         select (INamedTypeSymbol?)arg.Value.Value;

--- a/tests/Integration/AwsDependencyIntegrationTests.cs
+++ b/tests/Integration/AwsDependencyIntegrationTests.cs
@@ -24,7 +24,7 @@ using NUnit.Framework;
 
 namespace Lambdajection.Tests.Integration.AwsDependency
 {
-    [Lambda(Startup = typeof(Startup))]
+    [Lambda(typeof(Startup))]
     public partial class ExampleLambda
     {
         private readonly ExampleBar exampleBar;

--- a/tests/Integration/ConfigurationIntegrationTests.cs
+++ b/tests/Integration/ConfigurationIntegrationTests.cs
@@ -20,7 +20,7 @@ using NUnit.Framework;
 namespace Lambdajection.Tests.Integration.Configuration
 {
 
-    [Lambda(Startup = typeof(Startup))]
+    [Lambda(typeof(Startup))]
     public partial class ConfigurationLambda
     {
         private readonly ExampleOptions exampleOptions;

--- a/tests/Integration/NoFactoryCompilationTestProject/IntegrationTests.cs
+++ b/tests/Integration/NoFactoryCompilationTestProject/IntegrationTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Lambdajection.TestsWithoutFactories
 {
-    [Lambda(Startup = typeof(Startup))]
+    [Lambda(typeof(Startup))]
     public partial class TestLambda
     {
         private readonly S3Utility utility;

--- a/tests/Integration/SerializerIntegrationTests.cs
+++ b/tests/Integration/SerializerIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace Lambdajection.Tests.Integration.Serialization
 {
     public class TestSerializer { }
 
-    [Lambda(Startup = typeof(TestStartup), Serializer = typeof(TestSerializer))]
+    [Lambda(typeof(TestStartup), Serializer = typeof(TestSerializer))]
     public partial class TestLambdaWithSerializer
     {
 #pragma warning disable CA1822
@@ -25,7 +25,7 @@ namespace Lambdajection.Tests.Integration.Serialization
 #pragma warning restore CA1822
     }
 
-    [Lambda(Startup = typeof(TestStartup))]
+    [Lambda(typeof(TestStartup))]
     public partial class TestLambdaWithoutSerializer
     {
 #pragma warning disable CA1822


### PR DESCRIPTION
The startup argument in the Lambda attribute is now a constructor argument, rather than a named one.  This was done to enforce setting the argument earlier in the pipeline, rather than just failing during code generation.