### PR TITLE
LAMBJ-66 v0.4.0-beta2

### DIFF
--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -6,3 +6,4 @@ This release introduces the following:
   - Run decryption in parallel with other initialization services.
 - Fixes an issue where initialization services were getting called on every call to the Lambda.
 - Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.
+- Lambdajection.Attributes has been converted to a reference assembly so that it (and its dependencies) are not copied to the output folder of your project.  This package has always only contained symbols that are compile-time only, so this will simply free up space in deployment packages.

--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -1,2 +1,8 @@
 This release introduces the following:
-- 
+
+- Updates decryption to use initialization services for the following benefits:
+  - Avoid possibility of deadlocks by not using Task.WaitAll in the post configure hook.
+  - Run decryption on multiple IOptions in parallel
+  - Run decryption in parallel with other initialization services.
+- Fixes an issue where initialization services were getting called on every call to the Lambda.
+- Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.

--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -8,3 +8,4 @@ This release introduces the following:
 - Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.
 - Lambdajection.Attributes has been converted to a reference assembly so that it (and its dependencies) are not copied to the output folder of your project.  This package has always only contained symbols that are compile-time only, so this will simply free up space in deployment packages.
 - Bumped Amazon.Lambda.Serialization.SystemTextJson to v2.0.2
+- Now publishing Symbols + SourceLink information for Lambdajection.Encryption

--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -1,0 +1,2 @@
+This release introduces the following:
+- 

--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -7,3 +7,4 @@ This release introduces the following:
 - Fixes an issue where initialization services were getting called on every call to the Lambda.
 - Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.
 - Lambdajection.Attributes has been converted to a reference assembly so that it (and its dependencies) are not copied to the output folder of your project.  This package has always only contained symbols that are compile-time only, so this will simply free up space in deployment packages.
+- Bumped Amazon.Lambda.Serialization.SystemTextJson to v2.0.2

--- a/after.lambdajection.sln.targets
+++ b/after.lambdajection.sln.targets
@@ -9,7 +9,24 @@
             Projects="$(MSBuildThisFileDirectory)tests\Integration\NoFactoryCompilationTestProject\NoFactoryCompilationTestProject.csproj"
             Targets="Restore" />
     </Target>
-    
+
+    <Target Name="CheckFormatting" AfterTargets="Build">
+        <Message Importance="High" Text="%0A" />
+        
+        <Exec Command="dotnet format $(MSBuildThisFileDirectory)lambdajection.sln --fix-style info --check" ConsoleToMsBuild="true" IgnoreExitCode="true">
+            <Output TaskParameter="ExitCode" PropertyName="_FormatExitCode" />
+        </Exec>
+
+        <Message 
+            Importance="High" 
+            Condition="'$(_FormatExitCode)' != '0'"
+            Text="%0ARun the following command to attempt to automatically fix formatting issues:%0Adotnet format $(MSBuildThisFileDirectory)lambdajection.sln --fix-style info%0A" />
+
+        <Error 
+            Condition="'$(_FormatExitCode)' != '0'"
+            File="$(MSBuildThisFileDirectory)lambdajection.sln"
+            Text="Fix formatting issues." />
+    </Target>
 
     <Target Name="CleanExamples" AfterTargets="Clean">
         <Exec Command="dotnet nbgv get-version -v NuGetPackageVersion" ConsoleToMsBuild="true" StandardOutputImportance="Low">

--- a/src/Attributes/Attributes.csproj
+++ b/src/Attributes/Attributes.csproj
@@ -3,12 +3,22 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Lambdajection.Attributes</PackageId>
+    <NoWarn>NU5128;NU5131</NoWarn>
     <AssemblyName>$(PackageId)</AssemblyName>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
     <PackageDescription>Includes attributes needed for writing AWS Lambdas using Dependency Injection.</PackageDescription>
   </PropertyGroup>
+
+  <Target Name="_GetReferenceAssemblies" AfterTargets="Build" BeforeTargets="Pack">
+    <ItemGroup>
+      <ReferenceAssembliesOutput Include="@(IntermediateRefAssembly->'%(FullPath)')" TargetFramework="$(TargetFramework)" />
+      <ReferenceAssembliesOutput Include="@(DocumentationProjectOutputGroupOutput->'%(FullPath)')" TargetFramework="$(TargetFramework)" />
+      <None Include="@(ReferenceAssembliesOutput)" PackagePath="ref/%(ReferenceAssembliesOutput.TargetFramework)" Pack="true" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="Cythral.CodeGeneration.Roslyn.Attributes" Version="$(CythralCodeGenerationRoslynVersion)" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/LambdaHost.cs
+++ b/src/Core/LambdaHost.cs
@@ -26,7 +26,8 @@ namespace Lambdajection.Core
         /// <value>Provides services to the lambda.</value>
         public IServiceProvider ServiceProvider { get; internal set; } = null!;
 
-        private bool initialized = false;
+        /// <value>Whether the lambda host should run its initialization services.</value>
+        public bool RunInitializationServices { get; internal set; } = false;
 
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Lambdajection.Core
         /// <returns>The return value of the lambda.</returns>
         public async Task<TLambdaOutput> Run(TLambdaParameter parameter, ILambdaContext context)
         {
-            if (!initialized) await Initialize();
+            if (RunInitializationServices) await Initialize();
 
             using var scope = ServiceProvider.CreateScope();
             var service = scope.ServiceProvider.GetRequiredService<TLambda>();
@@ -67,7 +68,6 @@ namespace Lambdajection.Core
                 .Select(service => service.Initialize());
 
             await Task.WhenAll(tasks);
-            initialized = true;
         }
     }
 }

--- a/src/Core/LambdaHostBuilder.cs
+++ b/src/Core/LambdaHostBuilder.cs
@@ -13,10 +13,13 @@ namespace Lambdajection.Core
         where TLambdaConfigFactory : class, ILambdaConfigFactory, new()
     {
         internal static IServiceProvider serviceProvider = BuildServiceProvider();
+        internal static bool runInitializationServices = true;
 
         public static void Build(LambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory> host)
         {
             host.ServiceProvider = serviceProvider;
+            host.RunInitializationServices = runInitializationServices;
+            runInitializationServices = false;
         }
 
         public static IServiceProvider BuildServiceProvider()

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Amazon.Lambda.Serialization.SystemTextJson": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "WPtMxw5jwEcVbe0Ro/bF0VDnict/zoCW0r6dfRIIOthjO+fVMgDyGYa4Pkz6ptgCCFcnhQuOq6iebYw1LRZeIQ==",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "xh6nVPg5Iz75u+KTuSOh1P+L4k2HIi4Qz29LijgCcuZ0tTvmUOpNdWafwzaDD9fN+Q15BmzcO7l35/L3j5OGgA==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0"
         }

--- a/src/Encryption/Encryption.csproj
+++ b/src/Encryption/Encryption.csproj
@@ -5,6 +5,9 @@
     <PackageId>Lambdajection.Encryption</PackageId>
     <AssemblyName>$(PackageId)</AssemblyName>
     <PackageDescription>Provides an attribute and decryption service for encrypted configuration options that are injected into AWS Lambdas.</PackageDescription>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Generator/packages.lock.json
+++ b/src/Generator/packages.lock.json
@@ -53,8 +53,8 @@
       },
       "Amazon.Lambda.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "2.0.1",
-        "contentHash": "WPtMxw5jwEcVbe0Ro/bF0VDnict/zoCW0r6dfRIIOthjO+fVMgDyGYa4Pkz6ptgCCFcnhQuOq6iebYw1LRZeIQ==",
+        "resolved": "2.0.2",
+        "contentHash": "xh6nVPg5Iz75u+KTuSOh1P+L4k2HIi4Qz29LijgCcuZ0tTvmUOpNdWafwzaDD9fN+Q15BmzcO7l35/L3j5OGgA==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0"
         }
@@ -1174,7 +1174,7 @@
         "type": "Project",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0",
-          "Amazon.Lambda.Serialization.SystemTextJson": "2.0.1",
+          "Amazon.Lambda.Serialization.SystemTextJson": "2.0.2",
           "Lambdajection.Attributes": "1.0.0",
           "Microsoft.Extensions.Configuration": "3.1.6",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.6",

--- a/tests/Integration/NoFactoryCompilationTestProject/packages.lock.json
+++ b/tests/Integration/NoFactoryCompilationTestProject/packages.lock.json
@@ -58,8 +58,8 @@
       },
       "Amazon.Lambda.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "2.0.1",
-        "contentHash": "WPtMxw5jwEcVbe0Ro/bF0VDnict/zoCW0r6dfRIIOthjO+fVMgDyGYa4Pkz6ptgCCFcnhQuOq6iebYw1LRZeIQ==",
+        "resolved": "2.0.2",
+        "contentHash": "xh6nVPg5Iz75u+KTuSOh1P+L4k2HIi4Qz29LijgCcuZ0tTvmUOpNdWafwzaDD9fN+Q15BmzcO7l35/L3j5OGgA==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0"
         }
@@ -1188,7 +1188,7 @@
         "type": "Project",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0",
-          "Amazon.Lambda.Serialization.SystemTextJson": "2.0.1",
+          "Amazon.Lambda.Serialization.SystemTextJson": "2.0.2",
           "Lambdajection.Attributes": "1.0.0",
           "Microsoft.Extensions.Configuration": "3.1.6",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.6",

--- a/tests/Unit/Core/LambdaHostBuilderTests.cs
+++ b/tests/Unit/Core/LambdaHostBuilderTests.cs
@@ -58,6 +58,35 @@ namespace Lambdajection.Core.Tests
         }
 
         [Test]
+        public void BuildSetsRunInitializationServicesToTrueTheFirstTime()
+        {
+            var host = new TestLambdaHost(lambdaHost => { });
+            host.ServiceProvider.Should().BeNull();
+
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            TestLambdaHostBuilder.serviceProvider = serviceProvider;
+            TestLambdaHostBuilder.runInitializationServices = true;
+            TestLambdaHostBuilder.Build(host);
+
+            host.RunInitializationServices.Should().BeTrue();
+        }
+
+        [Test]
+        public void BuildSetsRunInitializationServicesToFalseTheSecondTime()
+        {
+            var host = new TestLambdaHost(lambdaHost => { });
+            host.ServiceProvider.Should().BeNull();
+
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            TestLambdaHostBuilder.serviceProvider = serviceProvider;
+            TestLambdaHostBuilder.runInitializationServices = true;
+            TestLambdaHostBuilder.Build(host);
+            TestLambdaHostBuilder.Build(host);
+
+            host.RunInitializationServices.Should().BeFalse();
+        }
+
+        [Test]
         public void BuildServiceProviderReturnsServiceProviderWithConfiguration()
         {
             var provider = TestLambdaHostBuilder.BuildServiceProvider();

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -169,8 +169,8 @@
       },
       "Amazon.Lambda.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "2.0.1",
-        "contentHash": "WPtMxw5jwEcVbe0Ro/bF0VDnict/zoCW0r6dfRIIOthjO+fVMgDyGYa4Pkz6ptgCCFcnhQuOq6iebYw1LRZeIQ==",
+        "resolved": "2.0.2",
+        "contentHash": "xh6nVPg5Iz75u+KTuSOh1P+L4k2HIi4Qz29LijgCcuZ0tTvmUOpNdWafwzaDD9fN+Q15BmzcO7l35/L3j5OGgA==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0"
         }
@@ -1417,7 +1417,7 @@
         "type": "Project",
         "dependencies": {
           "Amazon.Lambda.Core": "1.1.0",
-          "Amazon.Lambda.Serialization.SystemTextJson": "2.0.1",
+          "Amazon.Lambda.Serialization.SystemTextJson": "2.0.2",
           "Lambdajection.Attributes": "1.0.0",
           "Microsoft.Extensions.Configuration": "3.1.6",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.6",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.4.0-beta1",
+  "version": "0.4.0-beta2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d\\.\\d",


### PR DESCRIPTION
## Release Notes
This release introduces the following:

- Updates decryption to use initialization services for the following benefits:
  - Avoid possibility of deadlocks by not using Task.WaitAll in the post configure hook.
  - Run decryption on multiple IOptions in parallel
  - Run decryption in parallel with other initialization services.
- Fixes an issue where initialization services were getting called on every call to the Lambda.
- Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.
- Lambdajection.Attributes has been converted to a reference assembly so that it (and its dependencies) are not copied to the output folder of your project.  This package has always only contained symbols that are compile-time only, so this will simply free up space in deployment packages.
- Bumped Amazon.Lambda.Serialization.SystemTextJson to v2.0.2
- Now publishing Symbols + SourceLink information for Lambdajection.Encryption

## Stories
<ul>
<li>[<a href='https://cythral.atlassian.net/browse/LAMBJ-28'>LAMBJ-28</a>] -         Attributes Assembly Autoremoval
</li>
<li>[<a href='https://cythral.atlassian.net/browse/LAMBJ-66'>LAMBJ-66</a>] -         Release v0.4.0-beta2
</li>
<li>[<a href='https://cythral.atlassian.net/browse/LAMBJ-67'>LAMBJ-67</a>] -         <strike>Bump SDK to 3.1.402</strike>
</li>
<li>[<a href='https://cythral.atlassian.net/browse/LAMBJ-68'>LAMBJ-68</a>] -         Upgrade Serialization Library
</li>
<li>[<a href='https://cythral.atlassian.net/browse/LAMBJ-69'>LAMBJ-69</a>] -         Publish Symbols for Encryption Package
</li>
</ul>