### PR TITLE
LAMBJ-44 Decryption Initialization Service

### DIFF
--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -5,3 +5,4 @@ This release introduces the following:
   - Run decryption on multiple IOptions in parallel
   - Run decryption in parallel with other initialization services.
 - Fixes an issue where initialization services were getting called on every call to the Lambda.
+- Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.

--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -1,2 +1,7 @@
 This release introduces the following:
-- 
+
+- Updates decryption to use initialization services for the following benefits:
+  - Avoid possibility of deadlocks by not using Task.WaitAll in the post configure hook.
+  - Run decryption on multiple IOptions in parallel
+  - Run decryption in parallel with other initialization services.
+- Fixes an issue where initialization services were getting called on every call to the Lambda.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Test
         run: dotnet test --no-build
 
-      - name: Format
-        run: dotnet format lambdajection.sln --fix-style info --check
-
       - name: Run End to End Tests
         if: matrix.os == 'ubuntu-latest' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release/*' || contains(github.event.head_commit.message, '[e2e]'))
         run: dotnet build -t:EndToEndTests -p:PackageBucket=${{ secrets.ARTIFACT_BUCKET }} -p:RoleArn=${{ secrets.CLOUDFORMATION_ROLE_ARN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test
         run: dotnet test --no-build
 
+      - name: Format
+        run: dotnet format lambdajection.sln --fix-style info --check
+
       - name: Run End to End Tests
         if: matrix.os == 'ubuntu-latest' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release/*' || contains(github.event.head_commit.message, '[e2e]'))
         run: dotnet build -t:EndToEndTests -p:PackageBucket=${{ secrets.ARTIFACT_BUCKET }} -p:RoleArn=${{ secrets.CLOUDFORMATION_ROLE_ARN }}

--- a/after.lambdajection.sln.targets
+++ b/after.lambdajection.sln.targets
@@ -9,7 +9,24 @@
             Projects="$(MSBuildThisFileDirectory)tests\Integration\NoFactoryCompilationTestProject\NoFactoryCompilationTestProject.csproj"
             Targets="Restore" />
     </Target>
-    
+
+    <Target Name="CheckFormatting" AfterTargets="Build">
+        <Message Importance="High" Text="%0A" />
+        
+        <Exec Command="dotnet format $(MSBuildThisFileDirectory)lambdajection.sln --fix-style info --check" ConsoleToMsBuild="true" IgnoreExitCode="true">
+            <Output TaskParameter="ExitCode" PropertyName="_FormatExitCode" />
+        </Exec>
+
+        <Message 
+            Importance="High" 
+            Condition="'$(_FormatExitCode)' != '0'"
+            Text="%0ARun the following command to attempt to automatically fix formatting issues:%0Adotnet format $(MSBuildThisFileDirectory)lambdajection.sln --fix-style info%0A" />
+
+        <Error 
+            Condition="'$(_FormatExitCode)' != '0'"
+            File="$(MSBuildThisFileDirectory)lambdajection.sln"
+            Text="Fix formatting issues." />
+    </Target>
 
     <Target Name="CleanExamples" AfterTargets="Clean">
         <Exec Command="dotnet nbgv get-version -v NuGetPackageVersion" ConsoleToMsBuild="true" StandardOutputImportance="Low">

--- a/src/Core/LambdaHost.cs
+++ b/src/Core/LambdaHost.cs
@@ -26,7 +26,8 @@ namespace Lambdajection.Core
         /// <value>Provides services to the lambda.</value>
         public IServiceProvider ServiceProvider { get; internal set; } = null!;
 
-        private bool initialized = false;
+        /// <value>Whether the lambda host should run its initialization services.</value>
+        public bool RunInitializationServices { get; internal set; } = false;
 
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Lambdajection.Core
         /// <returns>The return value of the lambda.</returns>
         public async Task<TLambdaOutput> Run(TLambdaParameter parameter, ILambdaContext context)
         {
-            if (!initialized) await Initialize();
+            if (RunInitializationServices) await Initialize();
 
             using var scope = ServiceProvider.CreateScope();
             var service = scope.ServiceProvider.GetRequiredService<TLambda>();
@@ -67,7 +68,6 @@ namespace Lambdajection.Core
                 .Select(service => service.Initialize());
 
             await Task.WhenAll(tasks);
-            initialized = true;
         }
     }
 }

--- a/src/Core/LambdaHostBuilder.cs
+++ b/src/Core/LambdaHostBuilder.cs
@@ -13,10 +13,13 @@ namespace Lambdajection.Core
         where TLambdaConfigFactory : class, ILambdaConfigFactory, new()
     {
         internal static IServiceProvider serviceProvider = BuildServiceProvider();
+        internal static bool runInitializationServices = true;
 
         public static void Build(LambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory> host)
         {
             host.ServiceProvider = serviceProvider;
+            host.RunInitializationServices = runInitializationServices;
+            runInitializationServices = false;
         }
 
         public static IServiceProvider BuildServiceProvider()

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -27,7 +27,6 @@ namespace Lambdajection.Generator
         private readonly string startupTypeName;
         private string startupTypeDisplayName;
 
-
         private readonly string[] usings = new string[]
         {
             "System.Threading.Tasks",

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -25,7 +25,7 @@ namespace Lambdajection.Generator
         private readonly INamedTypeSymbol? serializerType;
         private readonly INamedTypeSymbol? configFactoryType;
         private readonly string startupTypeName;
-        private string startupTypeDisplayName;
+        private readonly string startupTypeDisplayName;
 
         private readonly string[] usings = new string[]
         {

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -258,7 +258,7 @@ namespace Lambdajection.Generator
 
                     if (optionClass.EncryptedProperties.Any())
                     {
-                        yield return ParseStatement($"services.AddSingleton<IPostConfigureOptions<{fullName}>, {sectionName}Decryptor>();");
+                        yield return ParseStatement($"services.AddSingleton<{nameof(ILambdaInitializationService)}, {sectionName}Decryptor>();");
                     }
 
                     yield return ParseStatement($"services.Configure<{fullName}>(configuration.GetSection(\"{optionClass.ConfigSectionName}\"));");
@@ -358,18 +358,20 @@ namespace Lambdajection.Generator
             var optionClassName = classDeclaration.Identifier.ValueText;
             var namespaceName = classDeclaration.Ancestors().OfType<NamespaceDeclarationSyntax>().ElementAt(0);
             var fullName = namespaceName.Name + "." + optionClassName;
-            var typeConstraints = new BaseTypeSyntax[] { SimpleBaseType(ParseTypeName($"IPostConfigureOptions<{fullName}>")) };
+            var typeConstraints = new BaseTypeSyntax[] { SimpleBaseType(ParseTypeName($"ILambdaInitializationService")) };
 
             MemberDeclarationSyntax GenerateConstructor()
             {
                 var parameters = SeparatedList(new ParameterSyntax[]
                 {
                     Parameter(List<AttributeListSyntax>(), TokenList(), ParseTypeName(nameof(IDecryptionService)), Identifier("decryptionService"), null),
+                    Parameter(List<AttributeListSyntax>(), TokenList(), ParseTypeName($"IOptions<{optionClassName}>"), Identifier("options"), null),
                 });
 
                 static IEnumerable<StatementSyntax> GenerateBody()
                 {
                     yield return ParseStatement("this.decryptionService = decryptionService;");
+                    yield return ParseStatement("this.options = options.Value;");
                 }
 
                 return ConstructorDeclaration($"{optionClass.ConfigSectionName}Decryptor")
@@ -378,54 +380,68 @@ namespace Lambdajection.Generator
                     .WithBody(Block(GenerateBody()));
             }
 
-            static MemberDeclarationSyntax GenerateDecryptionServiceField()
+            static MemberDeclarationSyntax GeneratePrivateField(string typeName, string name)
             {
                 var attributes = List<AttributeListSyntax>();
                 var modifiers = TokenList(Token(PrivateKeyword));
-                var type = ParseTypeName(nameof(IDecryptionService));
+                var type = ParseTypeName(typeName);
 
-                var variables = new VariableDeclaratorSyntax[] { VariableDeclarator("decryptionService") };
+                var variables = new VariableDeclaratorSyntax[] { VariableDeclarator(name) };
                 var variable = VariableDeclaration(type)
                     .WithVariables(SeparatedList(variables));
 
                 return FieldDeclaration(attributes, modifiers, variable);
             }
 
-            MemberDeclarationSyntax GeneratePostConfigureMethod()
+            MemberDeclarationSyntax GenerateInitializeMethod()
             {
-                var parameters = SeparatedList(new ParameterSyntax[]
+                IEnumerable<ExpressionSyntax> GenerateDecryptPropertyCalls()
                 {
-                    Parameter(List<AttributeListSyntax>(), TokenList(), ParseTypeName("string"), Identifier("name"), null),
-                    Parameter(List<AttributeListSyntax>(), TokenList(), ParseTypeName(fullName), Identifier("options"), null),
-                });
+                    foreach (var prop in optionClass.EncryptedProperties)
+                    {
+                        yield return ParseExpression($"Decrypt{prop}()");
+                    }
+                }
 
                 IEnumerable<StatementSyntax> GenerateBody()
                 {
+                    var initializerList = SeparatedList(GenerateDecryptPropertyCalls());
+                    var initializer = InitializerExpression(ArrayInitializerExpression, initializerList);
+                    var creationExpression = ObjectCreationExpression(ParseTypeName("Task[]"), null, initializer);
 
-                    var taskRunner = "Task.WaitAll(new Task[]\n{\n";
+                    var args = SeparatedList(new ArgumentSyntax[] { Argument(creationExpression) });
+                    var argList = ArgumentList(args);
+                    var whenAllExpression = InvocationExpression(ParseExpression("Task.WhenAll"), argList);
+                    var awaitExpression = AwaitExpression(whenAllExpression);
 
-                    foreach (var prop in optionClass.EncryptedProperties)
-                    {
-                        taskRunner += $"Task.Run(async () => options.{prop} = await decryptionService.Decrypt(options.{prop})),\n";
-                    }
-
-                    taskRunner += "});";
-                    yield return ParseStatement(taskRunner).NormalizeWhitespace();
+                    yield return ExpressionStatement(awaitExpression);
                 }
 
-                return MethodDeclaration(ParseTypeName("void"), "PostConfigure")
-                    .WithModifiers(TokenList(Token(PublicKeyword)))
-                    .WithParameterList(ParameterList(parameters))
+                return MethodDeclaration(ParseTypeName("Task"), "Initialize")
+                    .WithModifiers(TokenList(Token(PublicKeyword), Token(AsyncKeyword)))
                     .WithBody(Block(GenerateBody()));
             }
+
+            MemberDeclarationSyntax GenerateDecryptPropertyMethod(string prop)
+            {
+                var body = new StatementSyntax[] { ParseStatement($"options.{prop} = await decryptionService.Decrypt(options.{prop});") };
+
+                return MethodDeclaration(ParseTypeName("Task"), $"Decrypt{prop}")
+                    .WithModifiers(TokenList(Token(PrivateKeyword), Token(AsyncKeyword)))
+                    .WithBody(Block(body));
+            }
+
+            var decryptMethods = optionClass.EncryptedProperties.Select(prop => GenerateDecryptPropertyMethod(prop));
 
             return ClassDeclaration(optionClass.ConfigSectionName + "Decryptor")
                 .WithBaseList(BaseList(Token(ColonToken), SeparatedList(typeConstraints)))
                 .AddMembers(
-                    GenerateDecryptionServiceField(),
+                    GeneratePrivateField(nameof(IDecryptionService), "decryptionService"),
+                    GeneratePrivateField($"{optionClassName}", "options"),
                     GenerateConstructor(),
-                    GeneratePostConfigureMethod()
-                );
+                    GenerateInitializeMethod()
+                )
+                .AddMembers(decryptMethods.ToArray());
         }
 
         public static ClassDeclarationSyntax GenerateAwsFactory(string service, string interfaceName, string implementationName)

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -25,7 +25,7 @@ namespace Lambdajection.Generator
         private readonly INamedTypeSymbol? serializerType;
         private readonly INamedTypeSymbol? configFactoryType;
         private readonly string startupTypeName;
-        private readonly string startupTypeDisplayName;
+        private string startupTypeDisplayName;
 
 
         private readonly string[] usings = new string[]
@@ -395,17 +395,18 @@ namespace Lambdajection.Generator
 
             MemberDeclarationSyntax GenerateInitializeMethod()
             {
-                IEnumerable<ExpressionSyntax> GenerateDecryptPropertyCalls()
+                static IEnumerable<ExpressionSyntax> GenerateDecryptPropertyCalls(IEnumerable<string> properties)
                 {
-                    foreach (var prop in optionClass.EncryptedProperties)
+                    foreach (var prop in properties)
                     {
                         yield return ParseExpression($"Decrypt{prop}()");
                     }
                 }
 
-                static IEnumerable<StatementSyntax> GenerateBody()
+                IEnumerable<StatementSyntax> GenerateBody()
                 {
-                    var initializerList = SeparatedList(GenerateDecryptPropertyCalls());
+                    var calls = GenerateDecryptPropertyCalls(optionClass.EncryptedProperties);
+                    var initializerList = SeparatedList(calls);
                     var initializer = InitializerExpression(ArrayInitializerExpression, initializerList);
                     var creationExpression = ObjectCreationExpression(ParseTypeName("Task[]"), null, initializer);
 

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -403,7 +403,7 @@ namespace Lambdajection.Generator
                     }
                 }
 
-                IEnumerable<StatementSyntax> GenerateBody()
+                static IEnumerable<StatementSyntax> GenerateBody()
                 {
                     var initializerList = SeparatedList(GenerateDecryptPropertyCalls());
                     var initializer = InitializerExpression(ArrayInitializerExpression, initializerList);
@@ -422,7 +422,7 @@ namespace Lambdajection.Generator
                     .WithBody(Block(GenerateBody()));
             }
 
-            MemberDeclarationSyntax GenerateDecryptPropertyMethod(string prop)
+            static MemberDeclarationSyntax GenerateDecryptPropertyMethod(string prop)
             {
                 var body = new StatementSyntax[] { ParseStatement($"options.{prop} = await decryptionService.Decrypt(options.{prop});") };
 

--- a/tests/Unit/Core/LambdaHostBuilderTests.cs
+++ b/tests/Unit/Core/LambdaHostBuilderTests.cs
@@ -58,6 +58,35 @@ namespace Lambdajection.Core.Tests
         }
 
         [Test]
+        public void BuildSetsRunInitializationServicesToTrueTheFirstTime()
+        {
+            var host = new TestLambdaHost(lambdaHost => { });
+            host.ServiceProvider.Should().BeNull();
+
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            TestLambdaHostBuilder.serviceProvider = serviceProvider;
+            TestLambdaHostBuilder.runInitializationServices = true;
+            TestLambdaHostBuilder.Build(host);
+
+            host.RunInitializationServices.Should().BeTrue();
+        }
+
+        [Test]
+        public void BuildSetsRunInitializationServicesToFalseTheSecondTime()
+        {
+            var host = new TestLambdaHost(lambdaHost => { });
+            host.ServiceProvider.Should().BeNull();
+
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            TestLambdaHostBuilder.serviceProvider = serviceProvider;
+            TestLambdaHostBuilder.runInitializationServices = true;
+            TestLambdaHostBuilder.Build(host);
+            TestLambdaHostBuilder.Build(host);
+
+            host.RunInitializationServices.Should().BeFalse();
+        }
+
+        [Test]
         public void BuildServiceProviderReturnsServiceProviderWithConfiguration()
         {
             var provider = TestLambdaHostBuilder.BuildServiceProvider();


### PR DESCRIPTION
- Updates decryption to use initialization services for the following benefits:
  - Avoid possibility of deadlocks by not using Task.WaitAll in the post configure hook.
  - Run decryption on multiple IOptions in parallel
  - Run decryption in parallel with other initialization services.
- Fixes an issue where initialization services were getting called on every call to the Lambda.
- Now checking for correct formatting across the solution after every build, including in CICD.  This means PR checks will fail if your changes to not comply with our preferred code style.