### PR TITLE
LAMBJ-28 Attributes Reference Assembly

### DIFF
--- a/.github/releases/v0.4.0-beta2.md
+++ b/.github/releases/v0.4.0-beta2.md
@@ -1,2 +1,3 @@
 This release introduces the following:
-- 
+
+- Lambdajection.Attributes has been converted to a reference assembly so that it (and its dependencies) are not copied to the output folder of your project.  This package has always only contained symbols that are compile-time only, so this will simply free up space in deployment packages.

--- a/src/Attributes/Attributes.csproj
+++ b/src/Attributes/Attributes.csproj
@@ -9,7 +9,6 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <BuildDependsOn>$(BuildDependsOn);BuildExamples</BuildDependsOn>
     <PackageDescription>Includes attributes needed for writing AWS Lambdas using Dependency Injection.</PackageDescription>
   </PropertyGroup>
 

--- a/src/Attributes/Attributes.csproj
+++ b/src/Attributes/Attributes.csproj
@@ -3,12 +3,23 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Lambdajection.Attributes</PackageId>
+    <NoWarn>NU5128;NU5131</NoWarn>
     <AssemblyName>$(PackageId)</AssemblyName>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+    <BuildDependsOn>$(BuildDependsOn);BuildExamples</BuildDependsOn>
     <PackageDescription>Includes attributes needed for writing AWS Lambdas using Dependency Injection.</PackageDescription>
   </PropertyGroup>
+
+  <Target Name="_GetReferenceAssemblies" AfterTargets="Build" BeforeTargets="Pack">
+    <ItemGroup>
+      <ReferenceAssembliesOutput Include="@(IntermediateRefAssembly->'%(FullPath)')" TargetFramework="$(TargetFramework)" />
+      <ReferenceAssembliesOutput Include="@(DocumentationProjectOutputGroupOutput->'%(FullPath)')" TargetFramework="$(TargetFramework)" />
+      <None Include="@(ReferenceAssembliesOutput)" PackagePath="ref/%(ReferenceAssembliesOutput.TargetFramework)" Pack="true" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="Cythral.CodeGeneration.Roslyn.Attributes" Version="$(CythralCodeGenerationRoslynVersion)" />


### PR DESCRIPTION
Lambdajection.Attributes has been converted to a reference assembly so that it (and its dependencies) are not copied to the output folder of your project.  This package has always only contained symbols that are compile-time only, so this will simply free up space in deployment packages.