### PR TITLE
LAMBJ-16 Options Template Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,17 @@ Lambdajection .NET templates are available for your convenience.  Run `dotnet ne
 
 
 <!-- omit in toc -->
-### Lambdajection Project <small>(`dotnet new lambdajection`)</small>
+### Lambdajection Project
+```
+dotnet new lambdajection
+```
 Creates a new C# project with Lambdajection installed, plus boilerplate for a Lambda Handler and Startup class.
 
 <!-- omit in toc -->
-### Options Class <small>(`dotnet new lambdajection-options`)</small>
+### Options Class
+```
+dotnet new lambdajection-options
+```
 Creates a new Options class to be injected into your Lambda as an `IOption<>`.
 
 

--- a/templates/Options/.template.config/template.json
+++ b/templates/Options/.template.config/template.json
@@ -6,7 +6,7 @@
         "Cloud",
         "Lambda"
     ],
-    "name": "AWS Lambda using Lambdajection",
+    "name": "Lambdajection Options Class",
     "shortName": "lambdajection-options",
     "tags": {
         "language": "C#",


### PR DESCRIPTION
This fixes the options template name to better identify its template.  This was a copy-paste error.