### PR TITLE
LAMBJ-26 Disposable Lambdas

### DIFF
--- a/.github/releases/v0.5.0-beta1.md
+++ b/.github/releases/v0.5.0-beta1.md
@@ -1,4 +1,5 @@
 This release introduces the following:
 
-- .NET Templates are here!  Install via `dotnet new -i Lambdajection.Templates`.  Templates are available for both projects an options.
+- .NET Templates are here!  Install via `dotnet new -i Lambdajection.Templates`.  Templates are available for both projects and options.
+- IDisposable and IAsyncDisposable Lambdas are now fully supported.  Disposers will be called at the end of each invocation. If you implement both IDisposable and IAsyncDisposable, DisposeAsync will be preferred.
 - Upgrades Roslyn to 3.7.0 (via CodeGeneration.Roslyn) for latest bug and security fixes, along with increased nullability checks.  Addressed changes around new possible null references.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Community contribution/pull requests are welcome and encouraged! See the [contri
   - [4.4. Customizing Configuration](#44-customizing-configuration)
   - [4.5. Adding Options](#45-adding-options)
   - [4.6. Initialization Services](#46-initialization-services)
-  - [4.7. Handler Scheme](#47-handler-scheme)
+  - [4.7. Disposers](#47-disposers)
+  - [4.8. Handler Scheme](#48-handler-scheme)
 - [5. Examples](#5-examples)
 - [6. Acknowledgments](#6-acknowledgments)
 - [7. Donations](#7-donations)
@@ -268,9 +269,14 @@ namespace Your.Namespace
 ### 4.6. Initialization Services
 Initialization services can be used to initialize data or perform some task before the lambda is run.  Initialization services should implement [ILambdaInitializationService](src/Core/ILambdaInitializationService.cs) and be injected into the container as singletons at startup.
 
-### 4.7. Handler Scheme
+### 4.7. Disposers
+> ℹ Disposers will be fully supported starting in v0.5.0-beta1
 
-When configuring your lambda on AWS, the method name you'll want to use will be `Run` (NOT `Handle`). For context, `Run` is a static method is generated on your class during compilation that takes care of setting up the IoC container (if it hasn't been already).
+Disposers can be used to run object finalization and mark for garbage collection. Lambdajection supports Lambdas that implement either [IDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable), [IAsyncDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable) or both.  If you implement both, DisposeAsync will be preferred.
+
+### 4.8. Handler Scheme
+
+When configuring your lambda on AWS, the method name you'll want to use will be `Run` (NOT `Handle`). For context, `Run` is a static method generated on your class during compilation.  It takes care of setting up the IoC container, if it hasn't been setup already.
 
 So, going off the example above, the handler scheme would look like this:
 

--- a/src/Generator/LambdaGenerator.cs
+++ b/src/Generator/LambdaGenerator.cs
@@ -228,7 +228,7 @@ namespace Lambdajection.Generator
                 var configFactoryNamespace = configFactoryType?.ContainingNamespace?.ToString() ?? "Lambdajection.Core";
                 usingsAddedDuringGeneration.Add(configFactoryNamespace);
 
-                yield return ParseStatement($"var host = new LambdaHost<{className}, {inputType}, {returnType}, {startupTypeName}, LambdajectionConfigurator, {configFactory}>();");
+                yield return ParseStatement($"await using var host = new LambdaHost<{className}, {inputType}, {returnType}, {startupTypeName}, LambdajectionConfigurator, {configFactory}>();");
                 yield return ParseStatement($"return await host.Run({inputParameter!.Identifier.ValueText}, {contextParameter!.Identifier.ValueText});");
             }
 

--- a/tests/Common/AsyncDisposableLambda.cs
+++ b/tests/Common/AsyncDisposableLambda.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Lambdajection
+{
+#pragma warning disable CA1063,CA1816
+    public class AsyncDisposableLambda : TestLambda, IAsyncDisposable
+    {
+        public virtual async ValueTask DisposeAsync()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Common/DisposableLambda.cs
+++ b/tests/Common/DisposableLambda.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Lambdajection
+{
+#pragma warning disable CA1063,CA1816
+    public class DisposableLambda : TestLambda, IDisposable
+    {
+        public virtual void Dispose()
+        {
+            // do nothing
+        }
+    }
+}

--- a/tests/Common/MultiDisposableLambda.cs
+++ b/tests/Common/MultiDisposableLambda.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Lambdajection
+{
+#pragma warning disable CA1063,CA1816
+    public class MultiDisposableLambda : TestLambda, IAsyncDisposable, IDisposable
+    {
+        public virtual async ValueTask DisposeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public virtual void Dispose()
+        {
+            // do nothing
+        }
+    }
+}

--- a/tests/Integration/DisposableIntegrationTests.cs
+++ b/tests/Integration/DisposableIntegrationTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using FluentAssertions;
+
+using Lambdajection.Attributes;
+using Lambdajection.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+namespace Lambdajection.Tests.Integration.Disposable
+{
+
+    #region Setup
+
+    [Lambda(typeof(Startup))]
+    public sealed partial class DisposableLambda : IDisposable
+    {
+#pragma warning disable CA2211
+        public static bool DisposeWasCalled;
+#pragma warning restore CA2211
+
+        public Task<string> Handle(string request, ILambdaContext context)
+        {
+            return Task.FromResult(request);
+        }
+
+        public void Dispose()
+        {
+            DisposeWasCalled = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    [Lambda(typeof(Startup))]
+    public sealed partial class AsyncDisposableLambda : IAsyncDisposable
+    {
+#pragma warning disable CA2211
+        public static bool DisposeAsyncWasCalled;
+#pragma warning restore CA2211
+
+        public Task<string> Handle(string request, ILambdaContext context)
+        {
+            return Task.FromResult(request);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncWasCalled = true;
+
+#pragma warning disable CA1816
+            GC.SuppressFinalize(this);
+#pragma warning restore CA1816
+
+            return new ValueTask();
+        }
+    }
+
+    public class Startup : ILambdaStartup
+    {
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+    }
+
+    #endregion
+
+    #region Tests
+
+    [Category("Integration")]
+    public class DisposableIntegrationTests
+    {
+        [Test]
+        public async Task DisposeShouldBeCalled()
+        {
+            await DisposableLambda.Run("", null);
+            DisposableLambda.DisposeWasCalled.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task DisposeAsyncShouldBeCalled()
+        {
+            await AsyncDisposableLambda.Run("", null);
+            AsyncDisposableLambda.DisposeAsyncWasCalled.Should().BeTrue();
+        }
+    }
+
+    #endregion
+}

--- a/tests/Unit/Core/LambdaHostBuilderTests.cs
+++ b/tests/Unit/Core/LambdaHostBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 using FluentAssertions;
 
@@ -35,9 +36,9 @@ namespace Lambdajection.Core.Tests
     public class LambdaHostBuilderTests
     {
         [Test]
-        public void BuildSetsTheServiceProvider()
+        public async Task BuildSetsTheServiceProvider()
         {
-            var host = new TestLambdaHost(lambdaHost => { });
+            await using var host = new TestLambdaHost(lambdaHost => { });
             host.ServiceProvider.Should().BeNull();
 
             TestLambdaHostBuilder.Build(host);
@@ -45,9 +46,9 @@ namespace Lambdajection.Core.Tests
         }
 
         [Test]
-        public void BuildSetsTheServiceProviderIfItAlreadyWasBuilt()
+        public async Task BuildSetsTheServiceProviderIfItAlreadyWasBuilt()
         {
-            var host = new TestLambdaHost(lambdaHost => { });
+            await using var host = new TestLambdaHost(lambdaHost => { });
             host.ServiceProvider.Should().BeNull();
 
             var serviceProvider = Substitute.For<IServiceProvider>();
@@ -58,9 +59,9 @@ namespace Lambdajection.Core.Tests
         }
 
         [Test]
-        public void BuildSetsRunInitializationServicesToTrueTheFirstTime()
+        public async Task BuildSetsRunInitializationServicesToTrueTheFirstTime()
         {
-            var host = new TestLambdaHost(lambdaHost => { });
+            await using var host = new TestLambdaHost(lambdaHost => { });
             host.ServiceProvider.Should().BeNull();
 
             var serviceProvider = Substitute.For<IServiceProvider>();
@@ -72,9 +73,9 @@ namespace Lambdajection.Core.Tests
         }
 
         [Test]
-        public void BuildSetsRunInitializationServicesToFalseTheSecondTime()
+        public async Task BuildSetsRunInitializationServicesToFalseTheSecondTime()
         {
-            var host = new TestLambdaHost(lambdaHost => { });
+            await using var host = new TestLambdaHost(lambdaHost => { });
             host.ServiceProvider.Should().BeNull();
 
             var serviceProvider = Substitute.For<IServiceProvider>();


### PR DESCRIPTION
IDisposable and IAsyncDisposable Lambdas are now fully supported.  Disposers will be called at the end of each invocation. If you implement both IDisposable and IAsyncDisposable, DisposeAsync will be preferred.