### PR TITLE
LAMBJ-78 Disposable Initialization Services

### DIFF
--- a/.github/releases/v0.5.0-beta2.md
+++ b/.github/releases/v0.5.0-beta2.md
@@ -2,3 +2,4 @@ This release introduces the following:
 
 - Fixes an issue where several template symbols were being replaced where they should not be (ie Options being replaced in the LambdaOptions attribute if you specified a custom options class name).
 - Fixes an issue where an IAwsFactory was not being generated and added to the service collection for IAmazonSecurityTokenService.  This was not happening for any other service.
+- Initialization services that implement IAsyncDisposabe or IDisposable will now be properly disposed prior to running your Lambda's handler.

--- a/src/Core/LambdaHost.cs
+++ b/src/Core/LambdaHost.cs
@@ -71,11 +71,13 @@ namespace Lambdajection.Core
 
         private async Task Initialize()
         {
-            var tasks = ServiceProvider
-                .GetServices<ILambdaInitializationService>()
-                .Select(service => service.Initialize());
+            var services = ServiceProvider.GetServices<ILambdaInitializationService>();
 
-            await Task.WhenAll(tasks);
+            var initializeTasks = services.Select(service => service.Initialize());
+            await Task.WhenAll(initializeTasks);
+
+            var disposeTasks = services.Select(MaybeDispose);
+            await Task.WhenAll(disposeTasks);
         }
 
         /// <summary>
@@ -92,7 +94,7 @@ namespace Lambdajection.Core
             SuppressFinalize(this);
         }
 
-        private static async ValueTask MaybeDispose(object? obj)
+        private static async Task MaybeDispose(object? obj)
         {
             if (obj is IAsyncDisposable asyncDisposable)
             {


### PR DESCRIPTION
Initialization services that implement IAsyncDisposabe or IDisposable will now be properly disposed prior to running your Lambda's handler.