### PR TITLE
Build Settings Updates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,16 @@
         <Configuration Condition="$(Configuration) == ''">Debug</Configuration>
         <Nullable>enable</Nullable>
         <LangVersion>8.0</LangVersion>
+        <MinClientVersion>2.5</MinClientVersion>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <RestoreLockedMode>true</RestoreLockedMode>
+        <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -22,17 +32,11 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-        <RestoreLockedMode>true</RestoreLockedMode>
         <OutputPath>$(MSBuildThisFileDirectory)bin\$(MSBuildProjectName)\$(Configuration)</OutputPath>
         <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
         <PackageOutputPath>$(MSBuildThisFileDirectory)bin\Packages\$(Configuration)</PackageOutputPath>
         <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
         <CompilerGeneratedFilesOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)\$(Configuration)</CompilerGeneratedFilesOutputPath>
-        <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Metapackage/build/Lambdajection.targets
+++ b/src/Metapackage/build/Lambdajection.targets
@@ -5,6 +5,6 @@
     </PropertyGroup>
 
     <Target Name="Lambdajection_MinimumSdkRequirement" Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '$(MinimumNETCoreSdkVersion)'))">
-        <Error Text="Please upgrade your .NET SDK to $(MinimumNETCoreSdkVersion) in order to use Lambdajection" File="$(MSBuildThisFile)" />
+        <Error Text="Please upgrade your .NET SDK to at least $(MinimumNETCoreSdkVersion) in order to use Lambdajection" File="$(MSBuildThisFile)" />
     </Target>
 </Project>

--- a/src/Metapackage/build/Lambdajection.targets
+++ b/src/Metapackage/build/Lambdajection.targets
@@ -4,7 +4,7 @@
         <CoreCompileDependsOn>Lambdajection_MinimumSdkRequirement;$(CoreCompileDependsOn)</CoreCompileDependsOn>
     </PropertyGroup>
 
-    <Target Name="Lambdajection_MinimumSdkRequirement" Condition="$([System.Text.RegularExpressions.Regex]::Replace($(NETCoreSdkVersion), '-.*$', '')) &lt; 5.0.100">
+    <Target Name="Lambdajection_MinimumSdkRequirement" Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '$(MinimumNETCoreSdkVersion)'))">
         <Error Text="Please upgrade your .NET SDK to $(MinimumNETCoreSdkVersion) in order to use Lambdajection" File="$(MSBuildThisFile)" />
     </Target>
 </Project>


### PR DESCRIPTION
- Uses the MSBuild::VersionLessThan function for comparing version strings rather than numerical comparison. 
- Sets MinClientVersion to 2.5