### PR TITLE
LAMBJ-89 Allow Static Usings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,9 @@ dotnet_diagnostic.IDE0060.severity = none
 # Not necessary in test projects
 dotnet_diagnostic.CS1591.severity = none
 
+# Underscores in names
+dotnet_diagnostic.CA1707.severity = none
+
 [obj/**.{cs,csx}]
 # Unnecessary usings - we don't have much control over these
 dotnet_diagnostic.CS8019.severity = none

--- a/.github/releases/v0.5.0-beta3.md
+++ b/.github/releases/v0.5.0-beta3.md
@@ -1,3 +1,3 @@
 This release introduces the following:
 
-- 
+- Fixes an issue where adding a static using statement in a source document would result in a compilation failure.

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -27,4 +27,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Lambdajection.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Core/Properties.cs
+++ b/src/Core/Properties.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Lambdajection.Tests")]

--- a/src/Generator/GenerationContext.cs
+++ b/src/Generator/GenerationContext.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Lambdajection.Generator
+{
+    public class GenerationContext
+    {
+        public ClassDeclarationSyntax Declaration { get; init; }
+        public SyntaxTree SyntaxTree { get; init; }
+        public SemanticModel SemanticModel { get; init; }
+        public AttributeData AttributeData { get; init; }
+        public GeneratorExecutionContext SourceGeneratorContext { get; set; }
+        public CancellationToken CancellationToken { get; set; }
+        public INamedTypeSymbol StartupType { get; init; }
+        public INamedTypeSymbol? SerializerType { get; set; }
+        public INamedTypeSymbol? ConfigFactoryType { get; set; }
+        public string StartupTypeName { get; set; }
+        public string StartupTypeDisplayName { get; set; }
+        public HashSet<string> Usings { get; } = new HashSet<string>();
+        public GenerationSettings Settings { get; init; }
+    }
+}

--- a/src/Generator/GenerationSettings.cs
+++ b/src/Generator/GenerationSettings.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+namespace Lambdajection.Generator
+{
+    public class GenerationSettings
+    {
+        public bool Nullable { get; init; }
+        public bool GenerateEntrypoint { get; init; }
+        public bool IncludeAmazonFactories { get; init; }
+        public bool IncludeDefaultSerializer { get; init; }
+
+        public static GenerationSettings FromContext(GeneratorExecutionContext context)
+        {
+            var referencedAssemblies = context.Compilation.ReferencedAssemblyNames;
+            var includeAmazonFactories = referencedAssemblies.Any(assembly => assembly.Name == "AWSSDK.SecurityToken");
+            var includeDefaultSerializer = referencedAssemblies.Any(assembly => assembly.Name == "Amazon.Lambda.Serialization.SystemTextJson");
+
+            var options = context.AnalyzerConfigOptions.GlobalOptions;
+            options.TryGetValue("build_property.GenerateLambdajectionEntrypoint", out var generateLambdajectionEntrypoint);
+            options.TryGetValue("build_property.Nullable", out var nullable);
+
+            generateLambdajectionEntrypoint ??= "false";
+            nullable ??= "disable";
+
+            return new GenerationSettings
+            {
+                Nullable = nullable.Equals("enable", StringComparison.OrdinalIgnoreCase),
+                GenerateEntrypoint = generateLambdajectionEntrypoint.Equals("true", StringComparison.OrdinalIgnoreCase),
+                IncludeAmazonFactories = includeAmazonFactories,
+                IncludeDefaultSerializer = includeDefaultSerializer
+            };
+        }
+    }
+}

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -34,4 +34,8 @@
     <ProjectReference Include="../Encryption/Encryption.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Lambdajection.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Generator/UsingsGenerator.cs
+++ b/src/Generator/UsingsGenerator.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Lambdajection.Generator
+{
+    public class UsingsGenerator
+    {
+        private static readonly string[] DefaultUsings = new string[]
+        {
+            "System",
+            "System.Threading.Tasks",
+            "System.IO",
+            "Microsoft.Extensions.DependencyInjection",
+            "Microsoft.Extensions.DependencyInjection.Extensions",
+            "Microsoft.Extensions.Configuration",
+            "Amazon.Lambda.Core",
+            "Lambdajection.Core"
+        };
+
+        private readonly string[] defaultUsings;
+
+        public UsingsGenerator() : this(DefaultUsings)
+        {
+
+        }
+
+        internal UsingsGenerator(string[] defaultUsings)
+        {
+            this.defaultUsings = defaultUsings;
+        }
+
+        public IEnumerable<UsingDirectiveSyntax> Generate(GenerationContext context)
+        {
+            var usingsToEmit = new HashSet<string>(defaultUsings);
+            usingsToEmit.UnionWith(context.Usings);
+
+            var unitRoot = context.SyntaxTree.GetCompilationUnitRoot();
+
+            foreach (var @using in unitRoot.Usings)
+            {
+                usingsToEmit.Remove(@using.WithoutTrivia().Name.ToFullString());
+                yield return @using.WithoutTrivia();
+            }
+
+            foreach (var @using in usingsToEmit)
+            {
+                var name = ParseName(@using);
+                yield return UsingDirective(name);
+            }
+        }
+    }
+}

--- a/tests/Common/AutoAttribute.cs
+++ b/tests/Common/AutoAttribute.cs
@@ -1,0 +1,17 @@
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.NUnit3;
+
+class AutoAttribute : AutoDataAttribute
+{
+    public AutoAttribute() : base(Create) { }
+
+    public static IFixture Create()
+    {
+        var fixture = new Fixture();
+        fixture.Customize(new AutoNSubstituteCustomization());
+        fixture.Customizations.Insert(-1, new TargetRelay());
+        return fixture;
+    }
+
+}

--- a/tests/Common/TargetAttribute.cs
+++ b/tests/Common/TargetAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+[AttributeUsage(AttributeTargets.Parameter)]
+public class TargetAttribute : Attribute
+{
+    public TargetAttribute(Type? overridesType = null, string? overridesMemberName = null)
+    {
+        if (overridesType == null || overridesMemberName == null)
+        {
+            return;
+        }
+
+        var fieldsQuery = from member in overridesType.GetFields(BindingFlags.Static | BindingFlags.Public)
+                          where member.Name == overridesMemberName
+                          select member;
+
+        var value = (Dictionary<Type, object>?)fieldsQuery.First().GetValue(null!);
+        Overrides = value ?? Overrides;
+    }
+
+    public Dictionary<Type, object> Overrides { get; } = new Dictionary<Type, object>();
+}

--- a/tests/Common/TargetRelay.cs
+++ b/tests/Common/TargetRelay.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Kernel;
+
+public class TargetRelay : ISpecimenBuilder
+{
+    public object Create(object request, ISpecimenContext context)
+    {
+        var parameterRequest = request as ParameterInfo;
+        var targetAttribute = (TargetAttribute?)parameterRequest?.GetCustomAttribute(typeof(TargetAttribute), true);
+
+        if (parameterRequest == null || targetAttribute == null)
+        {
+            return new NoSpecimen();
+        }
+
+        var type = parameterRequest.ParameterType;
+        var constructors = from ctor in type.GetConstructors()
+                           where ctor.GetParameters().Any()
+                           select ctor;
+
+        var constructor = constructors.First();
+        var parameterTypes = from parameter in constructor.GetParameters()
+                             let @override = GetOrDefault(targetAttribute.Overrides, parameter.ParameterType)
+                             select
+                                @override ??
+                                context.Resolve(parameter.ParameterType) ??
+                                context.Resolve(new SubstituteRequest(parameter.ParameterType));
+
+        var parameters = parameterTypes.ToArray();
+        var instance = Activator.CreateInstance(type, parameters);
+        return instance ?? new NoSpecimen() as object;
+    }
+
+    private static object? GetOrDefault(Dictionary<Type, object> dictionary, Type key)
+    {
+        dictionary.TryGetValue(key, out object? result);
+        return result;
+    }
+}

--- a/tests/Integration/ConfigurationIntegrationTests.cs
+++ b/tests/Integration/ConfigurationIntegrationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -17,6 +16,9 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 
 using NUnit.Framework;
+
+// This is another test - can we use static usings in our source file? See LAMBJ-89
+using static System.Environment;
 
 namespace Lambdajection.Tests.Integration.Configuration
 {
@@ -76,8 +78,8 @@ namespace Lambdajection.Tests.Integration.Configuration
         [SetUp]
         public void SetupEnvironmentVariables()
         {
-            Environment.SetEnvironmentVariable("Example:ExampleConfigValue", exampleConfigValue);
-            Environment.SetEnvironmentVariable("Example:ExampleEncryptedValue", exampleEncryptedValue);
+            SetEnvironmentVariable("Example:ExampleConfigValue", exampleConfigValue);
+            SetEnvironmentVariable("Example:ExampleEncryptedValue", exampleEncryptedValue);
         }
 
 

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.2" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.14.0" />
+    <PackageReference Include="AutoFixture.NUnit3" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0-4.final" />

--- a/tests/Unit/Generator/UsingsGeneratorTests.cs
+++ b/tests/Unit/Generator/UsingsGeneratorTests.cs
@@ -1,0 +1,74 @@
+using AutoFixture.AutoNSubstitute;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Lambdajection.Generator.Tests
+{
+    [Category("Unit")]
+    public class UsingsGeneratorTests
+    {
+        [Test, Auto]
+        public void Generate_ShouldEmitUsingOnlyOnce_IfIsDefault_AndAddedAtRuntime(
+            string usingToEmit,
+            [Substitute] SyntaxTree syntaxTree
+        )
+        {
+            var defaultUsings = new[] { usingToEmit };
+            var generator = new UsingsGenerator(defaultUsings);
+
+            var root = CompilationUnit().WithUsings(List<UsingDirectiveSyntax>());
+            var context = new GenerationContext { SyntaxTree = syntaxTree };
+
+            syntaxTree.GetRoot().Returns(root);
+            context.Usings.Add(usingToEmit);
+
+            var result = generator.Generate(context);
+            result.Should().ContainSingle(directive => directive.Name.ToFullString() == usingToEmit);
+        }
+
+        [Test, Auto]
+        public void Generate_ShouldEmitUsingOnlyOnce_IfAlreadyInSourceDocument_AndAddedAtRuntime(
+            string usingToEmit,
+            [Substitute] SyntaxTree syntaxTree
+        )
+        {
+            var generator = new UsingsGenerator();
+            var usings = new[] { UsingDirective(ParseName(usingToEmit)) };
+            var root = CompilationUnit().WithUsings(List(usings));
+            var context = new GenerationContext { SyntaxTree = syntaxTree };
+
+            syntaxTree.GetRoot().Returns(root);
+            context.Usings.Add(usingToEmit);
+
+            var result = generator.Generate(context);
+            result.Should().ContainSingle(directive => directive.Name.ToFullString() == usingToEmit);
+        }
+
+        [Test, Auto]
+        public void Generate_ShouldEmitUsingOnlyOnce_IfIsDefault_AndAlreadyInSourceDocument(
+            string usingToEmit,
+            [Substitute] SyntaxTree syntaxTree
+        )
+        {
+            var defaultUsings = new[] { usingToEmit };
+            var usings = new[] { UsingDirective(ParseName(usingToEmit)) };
+            var generator = new UsingsGenerator(defaultUsings);
+            var root = CompilationUnit().WithUsings(List(usings));
+            var context = new GenerationContext { SyntaxTree = syntaxTree };
+
+            syntaxTree.GetRoot().Returns(root);
+
+            var result = generator.Generate(context);
+            result.Should().ContainSingle(directive => directive.Name.ToFullString() == usingToEmit);
+        }
+    }
+}

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -2,6 +2,26 @@
   "version": 1,
   "dependencies": {
     ".NETCoreApp,Version=v5.0": {
+      "AutoFixture.AutoNSubstitute": {
+        "type": "Direct",
+        "requested": "[4.14.0, )",
+        "resolved": "4.14.0",
+        "contentHash": "/CykcrwvB6/LD1zFvYXSGKwNMSCKx71p7Rd3pSWH47y5Iz0kwgI8zyI17+CQQ4ZQ16zlZEoz+l238K1DT4a6mw==",
+        "dependencies": {
+          "AutoFixture": "4.14.0",
+          "NSubstitute": "[2.0.3, 5.0.0)"
+        }
+      },
+      "AutoFixture.NUnit3": {
+        "type": "Direct",
+        "requested": "[4.14.0, )",
+        "resolved": "4.14.0",
+        "contentHash": "5m1sxG3VgRnj/nJnoG77kP0b+aeIw+dXdPPqFbmgQBAIeObsHqsEAQxEUP/8VyFlJAWA+jJ+Lh2SMaXEZiMvaQ==",
+        "dependencies": {
+          "AutoFixture": "4.14.0",
+          "NUnit": "[3.7.0, 4.0.0)"
+        }
+      },
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[3.5.2, )",
@@ -168,6 +188,15 @@
           "Amazon.Lambda.Core": "1.1.0"
         }
       },
+      "AutoFixture": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "Hs6Tcxd4gVZVPCNhuDccnpaBSvcbi33eIPiwAhKw+WRu5z1ClFIDamkw100oADo8Ay1HchGEBU8klwkJfCDMNg==",
+        "dependencies": {
+          "Fare": "[2.1.1, 3.0.0)",
+          "System.ComponentModel.Annotations": "4.3.0"
+        }
+      },
       "AWSSDK.Core": {
         "type": "Transitive",
         "resolved": "3.5.1.20",
@@ -196,6 +225,14 @@
           "System.Reflection.Emit": "4.3.0",
           "System.Reflection.TypeExtensions": "4.3.0",
           "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
+      "Fare": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "HaI8puqA66YU7/9cK4Sgbs1taUTP1Ssa4QT2PIzqJ7GvAbN1QgkjbRsjH+FSbMh1MJdvS0CIwQNLtFT+KF6KpA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
         }
       },
       "Humanizer.Core": {
@@ -698,6 +735,24 @@
         "contentHash": "VyGn1jGRZVfxnh8EdvDCi71v3bMXrsu8aYJOwoV7SNDLVhiEqwP86pPMyRGsDsxhXAm2b3o9OIqeETfN5qfezw==",
         "dependencies": {
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.Annotations": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SY2RLItHt43rd8J9D8M8e8NM4m+9WLN2uUd9G0n1I4hj/7w+v3pzK6ZBjexlG1/2xvLKQsqir3UGVSyBTXMLWA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0"
         }
       },
       "System.ComponentModel.EventBasedAsync": {


### PR DESCRIPTION
This fixes an issue where adding a static using in a source document would result in a compilation failure, due to the generator translating this into a normal using statement.