### PR TITLE
Test Command Fix

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\Core\Core.csproj" />
+    <ProjectReference Include="..\src\Core\Core.csproj" SetTargetFramework="TargetFramework=netstandard2.1"/>
     <ProjectReference Include="..\src\Attributes\Attributes.csproj" />
     <ProjectReference Include="..\src\Encryption\Encryption.csproj" />
     <ProjectReference Include="..\src\Generator\Generator.csproj" IncludeAssets="all" OutputItemType="Analyzer" />


### PR DESCRIPTION
Fixes an issue where running dotnet test without the --no-build flag would result in a compilation error.  