### PR TITLE
LAMBJ-97 Example Stack Cleanup

### DIFF
--- a/.github/releases/v0.6.0-beta1.md
+++ b/.github/releases/v0.6.0-beta1.md
@@ -2,3 +2,4 @@ This release introduces the following:
 
 - New Project Template Option: disposable - set this to true if you want the generataed Lambda to implement IAsyncDisposable and IDisposable.
 - Several examples have been updated to illustrate the use of the IAsyncDisposable / IDisposable pattern with Lambdajection.
+- As a housekeeping item, CloudFormation stacks for examples are now deleted after end to end tests have finished running.

--- a/examples/AwsClientFactories/AwsClientFactories.csproj
+++ b/examples/AwsClientFactories/AwsClientFactories.csproj
@@ -10,4 +10,18 @@
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.0" />
   </ItemGroup>
 
+  <Target Name="EndToEndTestCleanup">
+    <Exec
+      Command="aws cloudformation describe-stacks --stack-name $(LambdaName) --query &apos;Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue&apos; --output text"
+      StandardOutputImportance="low"
+      ConsoleToMsBuild="true"
+    >
+      <Output TaskParameter="ConsoleOutput" PropertyName="BucketName" />
+    </Exec>
+
+    <Exec
+      Command="aws s3 rb s3://$(BucketName) --force"
+      StandardOutputImportance="low"
+    />
+  </Target>
 </Project>

--- a/examples/AwsClientFactories/cloudformation.template.yml
+++ b/examples/AwsClientFactories/cloudformation.template.yml
@@ -27,6 +27,15 @@ Resources:
             Resource: !Sub arn:aws:s3:::${Bucket}/*
             Principal:
               AWS: !GetAtt PutBucketRole.Arn
+          - Effect: Allow
+            Action:
+              - s3:DeleteBucket
+              - s3:DeleteObject
+            Resource:
+              - !Sub arn:aws:s3:::${Bucket}
+              - !Sub arn:aws:s3:::${Bucket}/*
+            Principal:
+              AWS: !ImportValue lambdajection-infrastructure:GithubUserArn
 
   PutBucketRole:
     Type: AWS::IAM::Role

--- a/examples/AwsClientFactories/cloudformation.template.yml
+++ b/examples/AwsClientFactories/cloudformation.template.yml
@@ -31,6 +31,7 @@ Resources:
             Action:
               - s3:DeleteBucket
               - s3:DeleteObject
+              - s3:ListBucket
             Resource:
               - !Sub arn:aws:s3:::${Bucket}
               - !Sub arn:aws:s3:::${Bucket}/*

--- a/examples/AwsClientFactories/cloudformation.template.yml
+++ b/examples/AwsClientFactories/cloudformation.template.yml
@@ -40,6 +40,9 @@ Resources:
               AWS: !GetAtt AwsClientFactoriesRole.Arn
 
 Outputs:
+  BucketName:
+    Value: !Ref Bucket
+
   InputPayload:
     Value: !Sub |
       {

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <LangVersion>9.0</LangVersion>
         <Nullable>enable</Nullable>
+        <LambdaName>lambdajection-$(MSBuildProjectName.ToLower())</LambdaName>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -28,7 +29,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.2.3" PrivateAssets="all" />
+        <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.3.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0-4.final" PrivateAssets="all" />
     </ItemGroup>
+
+    <Target Name="EndToEndTestCleanup" />
 </Project>

--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -2,14 +2,13 @@
     <Target Name="EndToEndTest" DependsOnTargets="Publish" Condition="$(SkipEndToEndTest) != 'true'">
         <PropertyGroup>
             <_OutputFileName>$(IntermediateOutputPath)\$(ProjectName)-E2EResponse.txt</_OutputFileName>
-            <_LambdaName>lambdajection-$(ProjectName.ToLower())</_LambdaName>
         </PropertyGroup>
 
         <Deploy
             TemplateFile="$(MSBuildProjectDirectory)\cloudformation.template.yml"
             Package="true"
             PackageBucket="$(PackageBucket)"
-            StackName="$(_LambdaName)"
+            StackName="$(LambdaName)"
             ConfigFile="$(MSBuildProjectDirectory)\cloudformation.config.json"
             Capabilities="CAPABILITY_IAM;CAPABILITY_AUTO_EXPAND"
             RoleArn="$(RoleArn)"
@@ -17,15 +16,26 @@
 
         <Message Text="Running End to End Test for $(ProjectName)..." Importance="High" />
 
-        <Exec Command="aws cloudformation describe-stacks --stack-name $(_LambdaName) --query &apos;Stacks[0].Outputs[?OutputKey==`InputPayload`].OutputValue&apos; --output text" StandardOutputImportance="low" ConsoleToMsBuild="true">
+        <Exec
+            Command="aws cloudformation describe-stacks --stack-name $(LambdaName) --query &apos;Stacks[0].Outputs[?OutputKey==`InputPayload`].OutputValue&apos; --output text"
+            StandardOutputImportance="low"
+            ConsoleToMsBuild="true"
+        >
             <Output TaskParameter="ConsoleOutput" ItemName="_InputPayload" />
         </Exec>
 
-        <Exec Command="aws cloudformation describe-stacks --stack-name $(_LambdaName) --query &apos;Stacks[0].Outputs[?OutputKey==`ExpectedOutput`].OutputValue&apos; --output text" StandardOutputImportance="low" ConsoleToMsBuild="true">
+        <Exec
+            Command="aws cloudformation describe-stacks --stack-name $(LambdaName) --query &apos;Stacks[0].Outputs[?OutputKey==`ExpectedOutput`].OutputValue&apos; --output text"
+            StandardOutputImportance="low"
+            ConsoleToMsBuild="true"
+        >
             <Output TaskParameter="ConsoleOutput" ItemName="_ExpectedOutputLines" />
         </Exec>
 
-        <Exec Command="aws lambda invoke --function-name $(_LambdaName) --payload '@(_InputPayload, '')' $(_OutputFileName)" StandardOutputImportance="low" />
+        <Exec
+            Command="aws lambda invoke --function-name $(LambdaName) --payload '@(_InputPayload, '')' $(_OutputFileName)"
+            StandardOutputImportance="low"
+        />
 
         <ReadLinesFromFile File="$(_OutputFileName)">
             <Output TaskParameter="Lines" ItemName="_ActualOutputLines" />
@@ -35,6 +45,10 @@
             <_ActualOutput>@(_ActualOutputLines, '')</_ActualOutput>
             <_ExpectedOutput>@(_ExpectedOutputLines, '')</_ExpectedOutput>
         </PropertyGroup>
+
+        <Message Importance="High" Text="Cleaning up..." />
+        <CallTarget Targets="EndToEndTestCleanup" />
+        <DeleteStack StackName="$(LambdaName)" />
 
         <Message Text="Success!" Condition="$(_ActualOutput) == $(_ExpectedOutput)" Importance="High" />
         <Message Text="Failed!" Condition="$(_ActualOutput) != $(_ExpectedOutput)" Importance="High" />


### PR DESCRIPTION
As a housekeeping item, CloudFormation stacks for examples are now deleted after end to end tests have finished running.