### PR TITLE
LAMBJ-87 Context Constructor Argument

### DIFF
--- a/.github/releases/v0.6.0-beta1.md
+++ b/.github/releases/v0.6.0-beta1.md
@@ -1,5 +1,6 @@
 This release introduces the following:
 
-- New Project Template Option: disposable - set this to true if you want the generataed Lambda to implement IAsyncDisposable and IDisposable.
+- New Project Template Option: disposable - set this to true if you want the generated Lambda to implement IAsyncDisposable and IDisposable.
 - Several examples have been updated to illustrate the use of the IAsyncDisposable / IDisposable pattern with Lambdajection.
 - As a housekeeping item, CloudFormation stacks for examples are now deleted after end to end tests have finished running.
+- **BREAKING CHANGE**: The context parameter (ILambdaContext) has been removed from ILambda.Handle.  This can now (optionally) be accessed via a constructor argument instead.  This was done to simplify the composition process and reduce the number of arguments that Handle will have - we plan on introducing cancellation tokens in the future here instead.

--- a/examples/AwsClientFactories/Handler.cs
+++ b/examples/AwsClientFactories/Handler.cs
@@ -24,7 +24,7 @@ namespace Lambdajection.Examples.AwsClientFactories
             this.s3Factory = s3Factory;
         }
 
-        public async Task<string> Handle(Request request, ILambdaContext context)
+        public async Task<string> Handle(Request request)
         {
             s3Client = await s3Factory.Create(request.RoleArn);
 

--- a/examples/CustomConfiguration/Handler.cs
+++ b/examples/CustomConfiguration/Handler.cs
@@ -18,7 +18,7 @@ namespace Lambdajection.Examples.CustomConfiguration
             this.config = config.Value;
         }
 
-        public Task<string> Handle(object request, ILambdaContext context)
+        public Task<string> Handle(object request)
         {
             return Task.FromResult(config.Foo);
         }

--- a/examples/CustomRuntime/Handler.cs
+++ b/examples/CustomRuntime/Handler.cs
@@ -9,7 +9,7 @@ namespace Lambdajection.Examples.CustomRuntime
     [Lambda(typeof(Startup))]
     public partial class Handler
     {
-        public async Task<string> Handle(object request, ILambdaContext context)
+        public async Task<string> Handle(object request)
         {
             return await Task.FromResult("Hello World!");
         }

--- a/examples/CustomSerializer/Handler.cs
+++ b/examples/CustomSerializer/Handler.cs
@@ -24,7 +24,7 @@ namespace Lambdajection.Examples.CustomSerializer
             this.reader = reader;
         }
 
-        public async Task<ApplicationLoadBalancerResponse> Handle(ApplicationLoadBalancerRequest request, ILambdaContext context)
+        public async Task<ApplicationLoadBalancerResponse> Handle(ApplicationLoadBalancerRequest request)
         {
             var path = Regex.Replace(request.Path, @"^\/", "");
             var contents = await reader.ReadAsString(path);

--- a/examples/EncryptedOptions/Handler.cs
+++ b/examples/EncryptedOptions/Handler.cs
@@ -18,7 +18,7 @@ namespace Lambdajection.Examples.EncryptedOptions
             this.options = options.Value;
         }
 
-        public Task<string> Handle(object request, ILambdaContext context)
+        public Task<string> Handle(object request)
         {
             return Task.FromResult(options.EncryptedValue); // despite the name, this value will have already been decrypted for you.
         }

--- a/src/Core/ILambda.cs
+++ b/src/Core/ILambda.cs
@@ -1,7 +1,5 @@
 using System.Threading.Tasks;
 
-using Amazon.Lambda.Core;
-
 namespace Lambdajection.Core
 {
     /// <summary>
@@ -15,8 +13,7 @@ namespace Lambdajection.Core
         /// The lambda's entrypoint.
         /// </summary>
         /// <param name="parameter">The lambda's input parameter.</param>
-        /// <param name="context">The lambda's context object.</param>
         /// <returns>The lambda's return value.</returns>
-        Task<TLambdaOutput> Handle(TLambdaParameter parameter, ILambdaContext context);
+        Task<TLambdaOutput> Handle(TLambdaParameter parameter);
     }
 }

--- a/src/Core/LambdaScope.cs
+++ b/src/Core/LambdaScope.cs
@@ -1,0 +1,18 @@
+using Amazon.Lambda.Core;
+
+#pragma warning disable SA1600, CS1591
+
+namespace Lambdajection.Core
+{
+    /// <summary>
+    /// Container for lambda invocation-specific variables.
+    /// </summary>
+    public class LambdaScope
+    {
+        /// <summary>
+        /// Gets or sets the lambda context.
+        /// </summary>
+        /// <value>The lambda context.</value>
+        public virtual ILambdaContext? LambdaContext { get; set; }
+    }
+}

--- a/templates/Project/Handler.cs
+++ b/templates/Project/Handler.cs
@@ -17,7 +17,7 @@ namespace __Project__
         private bool disposed;
 
 #endif
-        public async Task<object> Handle(object request, ILambdaContext context)
+        public async Task<object> Handle(object request)
         {
             return await Task.FromResult(new { });
         }

--- a/tests/Common/TestLambda.cs
+++ b/tests/Common/TestLambda.cs
@@ -1,7 +1,5 @@
 using System.Threading.Tasks;
 
-using Amazon.Lambda.Core;
-
 using Lambdajection.Core;
 
 namespace Lambdajection
@@ -10,12 +8,9 @@ namespace Lambdajection
     {
         public object Request { get; set; } = null!;
 
-        public ILambdaContext? Context { get; set; }
-
-        public virtual Task<object> Handle(object request, ILambdaContext? context)
+        public virtual Task<object> Handle(object request)
         {
             Request = request;
-            Context = context;
 
             return Task.FromResult<object>(null!);
         }

--- a/tests/Compilation/Projects/ConfigFactory/Handler.cs
+++ b/tests/Compilation/Projects/ConfigFactory/Handler.cs
@@ -20,7 +20,7 @@ namespace Lambdajection.CompilationTests.ConfigFactory
             this.config = config;
         }
 
-        public Task<string> Handle(string _, ILambdaContext context)
+        public Task<string> Handle(string _)
         {
             var value = config.GetValue<string>("TestKey");
             return Task.FromResult(value);

--- a/tests/Compilation/Projects/Configuration/Handler.cs
+++ b/tests/Compilation/Projects/Configuration/Handler.cs
@@ -21,7 +21,7 @@ namespace Lambdajection.CompilationTests.Configuration
             this.exampleOptions = exampleOptions.Value;
         }
 
-        public Task<Options> Handle(string request, ILambdaContext context)
+        public Task<Options> Handle(string request)
         {
             return Task.FromResult(exampleOptions);
         }

--- a/tests/Compilation/Projects/Disposables/AsyncDisposableHandler.cs
+++ b/tests/Compilation/Projects/Disposables/AsyncDisposableHandler.cs
@@ -17,7 +17,7 @@ namespace Lambdajection.CompilationTests.Disposables
     {
         public bool DisposeAsyncWasCalled = false;
 
-        public Task<AsyncDisposableHandler> Handle(string request, ILambdaContext context)
+        public Task<AsyncDisposableHandler> Handle(string request)
         {
             return Task.FromResult(this);
         }

--- a/tests/Compilation/Projects/Disposables/DisposableHandler.cs
+++ b/tests/Compilation/Projects/Disposables/DisposableHandler.cs
@@ -17,7 +17,7 @@ namespace Lambdajection.CompilationTests.Disposables
     {
         public bool DisposeWasCalled = false;
 
-        public Task<DisposableHandler> Handle(string request, ILambdaContext context)
+        public Task<DisposableHandler> Handle(string request)
         {
             return Task.FromResult(this);
         }

--- a/tests/Compilation/Projects/LambdaContext/Handler.cs
+++ b/tests/Compilation/Projects/LambdaContext/Handler.cs
@@ -2,29 +2,27 @@ using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
 
-using Amazon.S3;
-
 using Lambdajection.Attributes;
 using Lambdajection.Core;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Lambdajection.CompilationTests.AmazonFactories
+namespace Lambdajection.CompilationTests.LambdaContext
 {
     [Lambda(typeof(Startup))]
     public partial class Handler
     {
-        private readonly S3Utility utility;
+        private readonly ILambdaContext context;
 
-        public Handler(S3Utility utility)
+        public Handler(ILambdaContext context)
         {
-            this.utility = utility;
+            this.context = context;
         }
 
-        public Task<IAwsFactory<IAmazonS3>> Handle(string request)
+        public Task<ILambdaContext> Handle(string request)
         {
-            return Task.FromResult(utility.Factory);
+            return Task.FromResult(context);
         }
     }
 }

--- a/tests/Compilation/Projects/LambdaContext/LambdaContext.csproj
+++ b/tests/Compilation/Projects/LambdaContext/LambdaContext.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS8019</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
+  </ItemGroup>
+</Project>

--- a/tests/Compilation/Projects/LambdaContext/Startup.cs
+++ b/tests/Compilation/Projects/LambdaContext/Startup.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Lambdajection.Attributes;
+using Lambdajection.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lambdajection.CompilationTests.LambdaContext
+{
+    public class Startup : ILambdaStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+    }
+}

--- a/tests/Compilation/Projects/Serializer/CustomSerializerHandler.cs
+++ b/tests/Compilation/Projects/Serializer/CustomSerializerHandler.cs
@@ -15,7 +15,7 @@ namespace Lambdajection.CompilationTests.Serializer
     [Lambda(typeof(Startup), Serializer = typeof(TestSerializer))]
     public partial class CustomSerializerHandler
     {
-        public Task<string> Handle(string request, ILambdaContext context)
+        public Task<string> Handle(string request)
         {
             return Task.FromResult("");
         }

--- a/tests/Compilation/Projects/Serializer/DefaultSerializerHandler.cs
+++ b/tests/Compilation/Projects/Serializer/DefaultSerializerHandler.cs
@@ -15,7 +15,7 @@ namespace Lambdajection.CompilationTests.Serializer
     [Lambda(typeof(Startup))]
     public partial class DefaultSerializerHandler
     {
-        public Task<string> Handle(string request, ILambdaContext context)
+        public Task<string> Handle(string request)
         {
             return Task.FromResult("");
         }

--- a/tests/Compilation/Projects/compilation-projects.sln
+++ b/tests/Compilation/Projects/compilation-projects.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serializer", "Serializer\Se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoHandleMethod", "NoHandleMethod\NoHandleMethod.csproj", "{B91ABA3F-12B2-4451-AAF0-63ABE1A13696}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LambdaContext", "LambdaContext\LambdaContext.csproj", "{158E8279-AA96-4505-99AA-315DB2E67892}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -100,5 +102,17 @@ Global
 		{B91ABA3F-12B2-4451-AAF0-63ABE1A13696}.Release|x64.Build.0 = Release|Any CPU
 		{B91ABA3F-12B2-4451-AAF0-63ABE1A13696}.Release|x86.ActiveCfg = Release|Any CPU
 		{B91ABA3F-12B2-4451-AAF0-63ABE1A13696}.Release|x86.Build.0 = Release|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Debug|x64.Build.0 = Debug|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Debug|x86.Build.0 = Debug|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Release|Any CPU.Build.0 = Release|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Release|x64.ActiveCfg = Release|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Release|x64.Build.0 = Release|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Release|x86.ActiveCfg = Release|Any CPU
+		{158E8279-AA96-4505-99AA-315DB2E67892}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/Compilation/Tests/LambdaContextTests.cs
+++ b/tests/Compilation/Tests/LambdaContextTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+#pragma warning disable SA1009
+namespace Lambdajection.Tests.Compilation
+{
+    [Category("Integration")]
+    public class LambdaContextTests
+    {
+        private const string projectPath = "Compilation/Projects/LambdaContext/LambdaContext.csproj";
+
+        private static Project project = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            project = await MSBuildProjectExtensions.LoadProject(projectPath);
+        }
+
+        [Test]
+        public async Task Run_ReturnsContext()
+        {
+            using var generation = await project.GenerateAssembly();
+            var (assembly, _) = generation;
+            var handlerType = assembly.GetType("Lambdajection.CompilationTests.LambdaContext.Handler")!;
+            var runMethod = handlerType.GetMethod("Run")!;
+
+            var context = Substitute.For<ILambdaContext>();
+            var result = await (Task<ILambdaContext>)runMethod.Invoke(null, new object[] { string.Empty, context })!;
+            result.Should().BeSameAs(context);
+        }
+    }
+}


### PR DESCRIPTION
The context parameter (ILambdaContext) has been removed from ILambda.Handle.  This can now (optionally) be accessed via a constructor argument instead.  This was done to simplify the composition process and reduce the number of arguments that Handle will have - we plan on introducing cancellation tokens in the future here instead.