### PR TITLE
CD Github Release: Fix Uploading Nugets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ steps.download.outputs.download-path }}/*.nupkg,${{ steps.download.outputs.download-path }}/*.snupkg"
+          artifacts: "${{ steps.download-nugets.outputs.download-path }}/*.nupkg,${{ steps.download.outputs.download-path }}/*.snupkg"
           bodyFile: ".github/releases/v${{ env.VERSION }}.md"
           tag: v${{ env.VERSION }}
           commit: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ steps.download-nugets.outputs.download-path }}/*.nupkg,${{ steps.download.outputs.download-path }}/*.snupkg"
+          artifacts: "${{ steps.download-nugets.outputs.download-path }}/*.nupkg,${{ steps.download-nugets.outputs.download-path }}/*.snupkg"
           bodyFile: ".github/releases/v${{ env.VERSION }}.md"
           tag: v${{ env.VERSION }}
           commit: ${{ github.sha }}


### PR DESCRIPTION
When the ci/cd workflow was updated to publish the layer to SAR, the nuget download id was changed to download-nugets but not updated in the github release step.  This fixes the github release step to use the correct download id.