### PR TITLE
LAMBJ-19 Task Cancellation

### DIFF
--- a/.github/releases/v0.6.0-beta4.md
+++ b/.github/releases/v0.6.0-beta4.md
@@ -1,3 +1,3 @@
 This release introduces the following:
 
-- 
+- **Breaking Change**: Lambdas now take a CancellationToken as a second argument and will gracefully stop execution when cancellation is requested.

--- a/examples/AwsClientFactories/Handler.cs
+++ b/examples/AwsClientFactories/Handler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -24,7 +25,7 @@ namespace Lambdajection.Examples.AwsClientFactories
             this.s3Factory = s3Factory;
         }
 
-        public async Task<string> Handle(Request request)
+        public async Task<string> Handle(Request request, CancellationToken cancellationToken = default)
         {
             s3Client = await s3Factory.Create(request.RoleArn);
 

--- a/examples/CustomConfiguration/Handler.cs
+++ b/examples/CustomConfiguration/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -18,7 +19,7 @@ namespace Lambdajection.Examples.CustomConfiguration
             this.config = config.Value;
         }
 
-        public Task<string> Handle(object request)
+        public Task<string> Handle(object request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(config.Foo);
         }

--- a/examples/CustomRuntime/Handler.cs
+++ b/examples/CustomRuntime/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -9,7 +10,7 @@ namespace Lambdajection.Examples.CustomRuntime
     [Lambda(typeof(Startup))]
     public partial class Handler
     {
-        public async Task<string> Handle(object request)
+        public async Task<string> Handle(object request, CancellationToken cancellationToken = default)
         {
             return await Task.FromResult("Hello World!");
         }

--- a/examples/CustomSerializer/Handler.cs
+++ b/examples/CustomSerializer/Handler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
@@ -24,7 +25,7 @@ namespace Lambdajection.Examples.CustomSerializer
             this.reader = reader;
         }
 
-        public async Task<ApplicationLoadBalancerResponse> Handle(ApplicationLoadBalancerRequest request)
+        public async Task<ApplicationLoadBalancerResponse> Handle(ApplicationLoadBalancerRequest request, CancellationToken cancellationToken = default)
         {
             var path = Regex.Replace(request.Path, @"^\/", "");
             var contents = await reader.ReadAsString(path);

--- a/examples/EncryptedOptions/Handler.cs
+++ b/examples/EncryptedOptions/Handler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
 
@@ -18,7 +19,7 @@ namespace Lambdajection.Examples.EncryptedOptions
             this.options = options.Value;
         }
 
-        public Task<string> Handle(object request)
+        public Task<string> Handle(object request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(options.EncryptedValue); // despite the name, this value will have already been decrypted for you.
         }

--- a/src/Core/ILambda.cs
+++ b/src/Core/ILambda.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Lambdajection.Core
@@ -13,7 +14,8 @@ namespace Lambdajection.Core
         /// The lambda's entrypoint.
         /// </summary>
         /// <param name="parameter">The lambda's input parameter.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The lambda's return value.</returns>
-        Task<TLambdaOutput> Handle(TLambdaParameter parameter);
+        Task<TLambdaOutput> Handle(TLambdaParameter parameter, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Core/ILambdaInitializationService.cs
+++ b/src/Core/ILambdaInitializationService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Lambdajection.Core
@@ -10,7 +11,8 @@ namespace Lambdajection.Core
         /// <summary>
         /// Runs the initialization service's instructions.
         /// </summary>
+        /// <param name="cancellationToken">Token used to cancel operation.</param>
         /// <returns>The initialization task.</returns>
-        Task Initialize();
+        Task Initialize(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Encryption/IDecryptionService.cs
+++ b/src/Encryption/IDecryptionService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Lambdajection.Encryption
@@ -11,7 +12,8 @@ namespace Lambdajection.Encryption
         /// Decrypts a value.
         /// </summary>
         /// <param name="ciphertext">The value to be decrypted.</param>
+        /// <param name="cancellationToken">Token to cancel the operation with.</param>
         /// <returns>The decrypted value.</returns>
-        Task<string> Decrypt(string ciphertext);
+        Task<string> Decrypt(string ciphertext, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Generator/LambdaCompilationScanner.cs
+++ b/src/Generator/LambdaCompilationScanner.cs
@@ -19,8 +19,8 @@ namespace Lambdajection.Generator
         private readonly Compilation compilation;
         private readonly string lambdaTypeName;
         private readonly string startupDisplayName;
-        private readonly HashSet<OptionClass> optionClasses = new HashSet<OptionClass>();
-        private readonly HashSet<AwsServiceMetadata> awsServices = new HashSet<AwsServiceMetadata>();
+        private readonly HashSet<OptionClass> optionClasses = new();
+        private readonly HashSet<AwsServiceMetadata> awsServices = new();
         private bool includeDecryptionFacade;
 
         public LambdaCompilationScanner(Compilation compilation, IEnumerable<SyntaxTree> syntaxTrees, string lambdaTypeName, string startupDisplayName)

--- a/src/Generator/UnitGenerator.cs
+++ b/src/Generator/UnitGenerator.cs
@@ -22,7 +22,7 @@ namespace Lambdajection.Generator
     [Generator]
     public class UnitGenerator : ISourceGenerator
     {
-        private readonly UsingsGenerator usingsGenerator = new UsingsGenerator();
+        private readonly UsingsGenerator usingsGenerator = new();
 
         public void Initialize(GeneratorInitializationContext context)
         {

--- a/src/Generator/UsingsGenerator.cs
+++ b/src/Generator/UsingsGenerator.cs
@@ -13,6 +13,7 @@ namespace Lambdajection.Generator
         private static readonly string[] DefaultUsings = new string[]
         {
             "System",
+            "System.Threading",
             "System.Threading.Tasks",
             "System.IO",
             "Microsoft.Extensions.DependencyInjection",

--- a/templates/Project/Handler.cs
+++ b/templates/Project/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -17,7 +18,7 @@ namespace __Project__
         private bool disposed;
 
 #endif
-        public async Task<object> Handle(object request)
+        public async Task<object> Handle(object request, CancellationToken cancellationToken = default)
         {
             return await Task.FromResult(new { });
         }

--- a/tests/Common/TestLambda.cs
+++ b/tests/Common/TestLambda.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Lambdajection.Core;
@@ -8,7 +9,7 @@ namespace Lambdajection
     {
         public object Request { get; set; } = null!;
 
-        public virtual Task<object> Handle(object request)
+        public virtual Task<object> Handle(object request, CancellationToken cancellationToken = default)
         {
             Request = request;
 

--- a/tests/Compilation/Projects/AmazonFactories/Handler.cs
+++ b/tests/Compilation/Projects/AmazonFactories/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -22,7 +23,7 @@ namespace Lambdajection.CompilationTests.AmazonFactories
             this.utility = utility;
         }
 
-        public Task<IAwsFactory<IAmazonS3>> Handle(string request)
+        public Task<IAwsFactory<IAmazonS3>> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(utility.Factory);
         }

--- a/tests/Compilation/Projects/ConfigFactory/Handler.cs
+++ b/tests/Compilation/Projects/ConfigFactory/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -20,7 +21,7 @@ namespace Lambdajection.CompilationTests.ConfigFactory
             this.config = config;
         }
 
-        public Task<string> Handle(string _)
+        public Task<string> Handle(string _, CancellationToken cancellationToken = default)
         {
             var value = config.GetValue<string>("TestKey");
             return Task.FromResult(value);

--- a/tests/Compilation/Projects/Configuration/Handler.cs
+++ b/tests/Compilation/Projects/Configuration/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -21,7 +22,7 @@ namespace Lambdajection.CompilationTests.Configuration
             this.exampleOptions = exampleOptions.Value;
         }
 
-        public Task<Options> Handle(string request)
+        public Task<Options> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(exampleOptions);
         }

--- a/tests/Compilation/Projects/CustomRunnerMethod/Handler.cs
+++ b/tests/Compilation/Projects/CustomRunnerMethod/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -13,7 +14,7 @@ namespace Lambdajection.CompilationTests.CustomRunnerMethod
     [Lambda(typeof(Startup), RunnerMethod = "Process")]
     public partial class Handler
     {
-        public Task<string> Handle(string request)
+        public Task<string> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult("Success");
         }

--- a/tests/Compilation/Projects/Disposables/AsyncDisposableHandler.cs
+++ b/tests/Compilation/Projects/Disposables/AsyncDisposableHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -17,7 +18,7 @@ namespace Lambdajection.CompilationTests.Disposables
     {
         public bool DisposeAsyncWasCalled = false;
 
-        public Task<AsyncDisposableHandler> Handle(string request)
+        public Task<AsyncDisposableHandler> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(this);
         }

--- a/tests/Compilation/Projects/Disposables/DisposableHandler.cs
+++ b/tests/Compilation/Projects/Disposables/DisposableHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -17,7 +18,7 @@ namespace Lambdajection.CompilationTests.Disposables
     {
         public bool DisposeWasCalled = false;
 
-        public Task<DisposableHandler> Handle(string request)
+        public Task<DisposableHandler> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(this);
         }

--- a/tests/Compilation/Projects/LambdaContext/Handler.cs
+++ b/tests/Compilation/Projects/LambdaContext/Handler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -20,7 +21,7 @@ namespace Lambdajection.CompilationTests.LambdaContext
             this.context = context;
         }
 
-        public Task<ILambdaContext> Handle(string request)
+        public Task<ILambdaContext> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/tests/Compilation/Projects/Serializer/CustomSerializerHandler.cs
+++ b/tests/Compilation/Projects/Serializer/CustomSerializerHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -15,7 +16,7 @@ namespace Lambdajection.CompilationTests.Serializer
     [Lambda(typeof(Startup), Serializer = typeof(TestSerializer))]
     public partial class CustomSerializerHandler
     {
-        public Task<string> Handle(string request)
+        public Task<string> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult("");
         }

--- a/tests/Compilation/Projects/Serializer/DefaultSerializerHandler.cs
+++ b/tests/Compilation/Projects/Serializer/DefaultSerializerHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
@@ -15,7 +16,7 @@ namespace Lambdajection.CompilationTests.Serializer
     [Lambda(typeof(Startup))]
     public partial class DefaultSerializerHandler
     {
-        public Task<string> Handle(string request)
+        public Task<string> Handle(string request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult("");
         }


### PR DESCRIPTION
**Breaking Change**: Lambdas now take a CancellationToken as a second argument and will gracefully stop execution when cancellation is requested.