### PR TITLE
LAMBJ-77 Use AutoFixture in Unit Tests

### DIFF
--- a/.github/releases/v0.6.0-beta4.md
+++ b/.github/releases/v0.6.0-beta4.md
@@ -1,3 +1,4 @@
 This release introduces the following:
 
 - **Breaking Change**: Lambdas now take a CancellationToken as a second argument and will gracefully stop execution when cancellation is requested.
+- Unit tests have been refactored to use AutoFixture where applicable to conform to best practices regarding generation of test data and setup.

--- a/tests/Unit/Core/LambdaConfigFactoryTests.cs
+++ b/tests/Unit/Core/LambdaConfigFactoryTests.cs
@@ -9,10 +9,11 @@ namespace Lambdajection.Core.Tests
     [Category("Unit")]
     public class LambdaConfigFactoryTests
     {
-        [Test]
-        public void CreateShouldAddEnvironmentVariables()
+        [Test, Auto]
+        public void CreateShouldAddEnvironmentVariables(
+            [Target] LambdaConfigFactory factory
+        )
         {
-            var factory = new LambdaConfigFactory();
             var configuration = factory.Create();
             configuration.Providers.Should().Contain(provider => provider.GetType() == typeof(EnvironmentVariablesConfigurationProvider));
         }


### PR DESCRIPTION
This converts unit tests to use autofixture where applicable to conform to best practices regarding generation of test data and setup.
