### PR TITLE
Automatic update of Microsoft.Extensions.Configuration.Json to 5.0.0

### DIFF
--- a/examples/CustomConfiguration/CustomConfiguration.csproj
+++ b/examples/CustomConfiguration/CustomConfiguration.csproj
@@ -13,6 +13,6 @@
 
     <ItemGroup>
         <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     </ItemGroup>
 </Project>

--- a/tests/Compilation/Projects/ConfigFactory/ConfigFactory.csproj
+++ b/tests/Compilation/Projects/ConfigFactory/ConfigFactory.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Configuration.Json` to `5.0.0` from `3.1.8`
`Microsoft.Extensions.Configuration.Json 5.0.0` was published at `2020-11-09T23:40:12Z`, 3 months ago

2 project updates:
Updated `examples/CustomConfiguration/CustomConfiguration.csproj` to `Microsoft.Extensions.Configuration.Json` `5.0.0` from `3.1.8`
Updated `tests/Compilation/Projects/ConfigFactory/ConfigFactory.csproj` to `Microsoft.Extensions.Configuration.Json` `5.0.0` from `3.1.8`

[Microsoft.Extensions.Configuration.Json 5.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json/5.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
