### PR TITLE
Automatic update of coverlet.collector to 3.0.2

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.37" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -42,9 +42,9 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[1.3.0, )",
-        "resolved": "1.3.0",
-        "contentHash": "t8pnf5SX2ya0RX4vjoxsbhDMQCZJcpPun2neHKJ4FouMmObylo25FvoOydvf3Bl+l+IzWw7u2vjEeCBHnleB9g=="
+        "requested": "[3.0.2, )",
+        "resolved": "3.0.2",
+        "contentHash": "iBvPAIDaI7j/iMx/DzCGCJ3rdiOmel9VINEfaTiBv/NKIGHOP4X3hqc6Q1wgMtArEshlhXexQknP17SK4vXb1w=="
       },
       "FluentAssertions": {
         "type": "Direct",


### PR DESCRIPTION
NuKeeper has generated a major update of `coverlet.collector` to `3.0.2` from `1.3.0`
`coverlet.collector 3.0.2` was published at `2021-01-24T13:16:46Z`, 9 days ago

1 project update:
Updated `tests/Tests.csproj` to `coverlet.collector` `3.0.2` from `1.3.0`

[coverlet.collector 3.0.2 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
