### PR TITLE
Automatic update of Amazon.Lambda.ApplicationLoadBalancerEvents to 2.1.0

### DIFF
--- a/examples/CustomSerializer/CustomSerializer.csproj
+++ b/examples/CustomSerializer/CustomSerializer.csproj
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
-        <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.0.0" />
+        <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Amazon.Lambda.ApplicationLoadBalancerEvents` to `2.1.0` from `2.0.0`
`Amazon.Lambda.ApplicationLoadBalancerEvents 2.1.0` was published at `2020-10-21T23:12:51Z`, 4 months ago

1 project update:
Updated `examples/CustomSerializer/CustomSerializer.csproj` to `Amazon.Lambda.ApplicationLoadBalancerEvents` `2.1.0` from `2.0.0`

[Amazon.Lambda.ApplicationLoadBalancerEvents 2.1.0 on NuGet.org](https://www.nuget.org/packages/Amazon.Lambda.ApplicationLoadBalancerEvents/2.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
