### PR TITLE
Automatic update of Microsoft.Build.Locator to 1.4.1

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -67,9 +67,9 @@
       },
       "Microsoft.Build.Locator": {
         "type": "Direct",
-        "requested": "[1.3.2, )",
-        "resolved": "1.3.2",
-        "contentHash": "PaKm+D0ZZXmh5UGoDUpOkP3E3m40jCts+ZgqkTo76g+vBboPp/jq4/LVkm0rrSYFoYAq3oZODeAP6dhQ9lqelw=="
+        "requested": "[1.4.1, )",
+        "resolved": "1.4.1",
+        "contentHash": "UfyGaxNTjw/r3uWMX/Cv1CPKELo7TCrR5VIahaSKL0WyqmbDT6og9pyjwuhyyUkxC9gk2ElB7oOEySL1OzTZ1g=="
       },
       "Microsoft.CodeAnalysis": {
         "type": "Direct",


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Build.Locator` to `1.4.1` from `1.3.2`
`Microsoft.Build.Locator 1.4.1` was published at `2021-01-21T20:09:11Z`, 11 days ago

1 project update:
Updated `tests/Tests.csproj` to `Microsoft.Build.Locator` `1.4.1` from `1.3.2`

[Microsoft.Build.Locator 1.4.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Locator/1.4.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
