### PR TITLE
Automatic update of AWSSDK.Core to 3.5.2.5

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.57" PrivateAssets="all" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.2.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "AWSSDK.Core": {
         "type": "Direct",
-        "requested": "[3.5.1.57, )",
-        "resolved": "3.5.1.57",
-        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA=="
+        "requested": "[3.5.2.5, )",
+        "resolved": "3.5.2.5",
+        "contentHash": "mt/KXCxWOutWiOWyf/a/3LH9nsexqdIj55DSy4sePUUWUzDPm09QRFcHcDNDS5qVzr4kk2TBiqgQnWSVHUtCMA=="
       },
       "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
         "type": "Direct",
@@ -217,9 +217,9 @@
       },
       "AWSSDK.Core": {
         "type": "Direct",
-        "requested": "[3.5.1.57, )",
-        "resolved": "3.5.1.57",
-        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA==",
+        "requested": "[3.5.2.5, )",
+        "resolved": "3.5.2.5",
+        "contentHash": "mt/KXCxWOutWiOWyf/a/3LH9nsexqdIj55DSy4sePUUWUzDPm09QRFcHcDNDS5qVzr4kk2TBiqgQnWSVHUtCMA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
         }
@@ -490,9 +490,9 @@
       },
       "AWSSDK.Core": {
         "type": "Direct",
-        "requested": "[3.5.1.57, )",
-        "resolved": "3.5.1.57",
-        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA=="
+        "requested": "[3.5.2.5, )",
+        "resolved": "3.5.2.5",
+        "contentHash": "mt/KXCxWOutWiOWyf/a/3LH9nsexqdIj55DSy4sePUUWUzDPm09QRFcHcDNDS5qVzr4kk2TBiqgQnWSVHUtCMA=="
       },
       "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
         "type": "Direct",

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <!-- AWSSDK.Core here for getting path to package, needed for loading Lambdajection.Core types -->
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.57" GeneratePathProperty="true" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.2.5" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
   </ItemGroup>

--- a/src/Generator/packages.lock.json
+++ b/src/Generator/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.1": {
       "AWSSDK.Core": {
         "type": "Direct",
-        "requested": "[3.5.1.57, )",
-        "resolved": "3.5.1.57",
-        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA==",
+        "requested": "[3.5.2.5, )",
+        "resolved": "3.5.2.5",
+        "contentHash": "mt/KXCxWOutWiOWyf/a/3LH9nsexqdIj55DSy4sePUUWUzDPm09QRFcHcDNDS5qVzr4kk2TBiqgQnWSVHUtCMA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
         }


### PR DESCRIPTION
NuKeeper has generated a patch update of `AWSSDK.Core` to `3.5.2.5` from `3.5.1.57`
`AWSSDK.Core 3.5.2.5` was published at `2021-01-30T02:27:39Z`, 3 days ago

2 project updates:
Updated `src/Generator/Generator.csproj` to `AWSSDK.Core` `3.5.2.5` from `3.5.1.57`
Updated `src/Core/Core.csproj` to `AWSSDK.Core` `3.5.2.5` from `3.5.1.57`

[AWSSDK.Core 3.5.2.5 on NuGet.org](https://www.nuget.org/packages/AWSSDK.Core/3.5.2.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
