### PR TITLE
Automatic update of NUnit to 3.13.1

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.9.0-rc.7046" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.3.1" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -145,9 +145,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[3.12.0, )",
-        "resolved": "3.12.0",
-        "contentHash": "3oJTrcUcT9wmweBUwgUf0f1XIYy6RZq2ziV+RM95HMKAJGsHPN2i3MKK1dAPvDPMRLz799Llj4eyu/STB9Q7OA==",
+        "requested": "[3.13.1, )",
+        "resolved": "3.13.1",
+        "contentHash": "vWBvrSelmTYwqHWvO3dA63z7cOpaFR/3nJ9MMVLBkWeaWa7oiglPPm5g1h96B4i2XXqjFexxhR5MyMjmIJYPfg==",
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit` to `3.13.1` from `3.12.0`
`NUnit 3.13.1` was published at `2021-02-01T01:29:59Z`, 1 day ago

1 project update:
Updated `tests/Tests.csproj` to `NUnit` `3.13.1` from `3.12.0`

[NUnit 3.13.1 on NuGet.org](https://www.nuget.org/packages/NUnit/3.13.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
