### PR TITLE
Automatic update of AWSSDK.S3 to 3.5.7.12

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.7.12" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.37" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -24,11 +24,11 @@
       },
       "AWSSDK.S3": {
         "type": "Direct",
-        "requested": "[3.5.7.4, )",
-        "resolved": "3.5.7.4",
-        "contentHash": "oNeE7WMvmvS6MHqAs3+wBnRZxxbCXVAGFVirAx6m6DykoN6233vIG7AjxjPSKxw6KbIxoeUafH23TT+fBbjwng==",
+        "requested": "[3.5.7.12, )",
+        "resolved": "3.5.7.12",
+        "contentHash": "rt/68O9lQqWS9K/7HjrWdM04Xi7qEmjT8xq+GTj/SXOTG94OdZ0E4o1iDjCojTcc3svjVTLYqHgcvZm9bLWC/A==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.57, 3.6.0)"
+          "AWSSDK.Core": "[3.5.2.4, 3.6.0)"
         }
       },
       "AWSSDK.SecurityToken": {
@@ -222,8 +222,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.1.57",
-        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA=="
+        "resolved": "3.5.2.4",
+        "contentHash": "dm3hMqJieiySx1sVTtr+7r2BuAKQErySbU8t90uQ7tWpQCboHSigez8A5V4IuAEcAofkzMDXnKh3sIqV53iKzQ=="
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",


### PR DESCRIPTION
NuKeeper has generated a  update of `AWSSDK.S3` to `3.5.7.12` from `3.5.7.4`
`AWSSDK.S3 3.5.7.12` was published at `2021-01-29T20:56:16Z`, 4 days ago

1 project update:
Updated `tests/Tests.csproj` to `AWSSDK.S3` `3.5.7.12` from `3.5.7.4`

[AWSSDK.S3 3.5.7.12 on NuGet.org](https://www.nuget.org/packages/AWSSDK.S3/3.5.7.12)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
