### PR TITLE
Automatic update of AWSSDK.SecurityToken to 3.5.1.45

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.5.7.4" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.37" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.45" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" PrivateAssets="all" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -33,11 +33,11 @@
       },
       "AWSSDK.SecurityToken": {
         "type": "Direct",
-        "requested": "[3.5.1.37, )",
-        "resolved": "3.5.1.37",
-        "contentHash": "zpWQpXHResEjObtx4suPWVztSJXf++JD4UlwQOPbmzLfGBNKSaR/wi/kCy5VpTkBApqOJSALQz2Zpmw5lqqcmw==",
+        "requested": "[3.5.1.45, )",
+        "resolved": "3.5.1.45",
+        "contentHash": "idIeyWNeB2sYgha8VpV0FxMU4NBheEu1WOGhNsylTFv19lUyuwKgBURQaMeIndxuQjBkCSa+UjkyMUlXjTU9uw==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.57, 3.6.0)"
+          "AWSSDK.Core": "[3.5.2.4, 3.6.0)"
         }
       },
       "coverlet.collector": {
@@ -222,8 +222,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.1.57",
-        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA=="
+        "resolved": "3.5.2.4",
+        "contentHash": "dm3hMqJieiySx1sVTtr+7r2BuAKQErySbU8t90uQ7tWpQCboHSigez8A5V4IuAEcAofkzMDXnKh3sIqV53iKzQ=="
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",


### PR DESCRIPTION
NuKeeper has generated a  update of `AWSSDK.SecurityToken` to `3.5.1.45` from `3.5.1.37`
`AWSSDK.SecurityToken 3.5.1.45` was published at `2021-01-29T20:56:37Z`, 4 days ago

1 project update:
Updated `tests/Tests.csproj` to `AWSSDK.SecurityToken` `3.5.1.45` from `3.5.1.37`

[AWSSDK.SecurityToken 3.5.1.45 on NuGet.org](https://www.nuget.org/packages/AWSSDK.SecurityToken/3.5.1.45)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
