### PR TITLE
Automatic update of AWSSDK.S3 to 3.5.8

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.12" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.8" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.45" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "AWSSDK.S3": {
         "type": "Direct",
-        "requested": "[3.5.7.12, )",
-        "resolved": "3.5.7.12",
-        "contentHash": "rt/68O9lQqWS9K/7HjrWdM04Xi7qEmjT8xq+GTj/SXOTG94OdZ0E4o1iDjCojTcc3svjVTLYqHgcvZm9bLWC/A==",
+        "requested": "[3.5.8, )",
+        "resolved": "3.5.8",
+        "contentHash": "5S/EXknQmUjK7mE5fR32CnIWTNa8ySFQgE3Jq3MRLXPajvALK1Zz5nX1JP1zQd8IE4Q12OTyJKKxgnjyp5nMDg==",
         "dependencies": {
           "AWSSDK.Core": "[3.5.2.4, 3.6.0)"
         }


### PR DESCRIPTION
NuKeeper has generated a patch update of `AWSSDK.S3` to `3.5.8` from `3.5.7.12`
`AWSSDK.S3 3.5.8` was published at `2021-02-02T23:22:11Z`, 16 hours ago

1 project update:
Updated `tests/Tests.csproj` to `AWSSDK.S3` `3.5.8` from `3.5.7.12`

[AWSSDK.S3 3.5.8 on NuGet.org](https://www.nuget.org/packages/AWSSDK.S3/3.5.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
