### PR TITLE
LAMBJ-115 Automatically Determine AWSSDK.Core Version for Layer

### DIFF
--- a/src/Layer/Layer.csproj
+++ b/src/Layer/Layer.csproj
@@ -31,6 +31,7 @@
             <StoreArgs Include="--skip-optimization" Condition="!$([MSBuild]::IsOsPlatform('linux'))" />
             <StoreArgs Include="/p:Configuration=$(Configuration)" />
             <StoreArgs Include="/p:LambdajectionVersion=$(PackageVersion)" />
+            <StoreArgs Include="/v:diag" />
         </ItemGroup>
 
         <MakeDir Directories="$(MSBuildThisFileDirectory)Manifest/.nuget" />
@@ -40,7 +41,7 @@
         </PropertyGroup>
 
         <RemoveDir Directories="$(DirectoriesToRemove)" />
-        <Exec Command="dotnet store @(StoreArgs, ' ')" StandardOutputImportance="low" />
+        <Exec Command="dotnet store @(StoreArgs, ' ') > build.log" StandardOutputImportance="low" />
 
         <ItemGroup>
             <Content Include="$(OutputPath)layer/x64/net5.0/artifact.xml" />

--- a/src/Layer/Layer.csproj
+++ b/src/Layer/Layer.csproj
@@ -31,7 +31,6 @@
             <StoreArgs Include="--skip-optimization" Condition="!$([MSBuild]::IsOsPlatform('linux'))" />
             <StoreArgs Include="/p:Configuration=$(Configuration)" />
             <StoreArgs Include="/p:LambdajectionVersion=$(PackageVersion)" />
-            <StoreArgs Include="/v:diag" />
         </ItemGroup>
 
         <MakeDir Directories="$(MSBuildThisFileDirectory)Manifest/.nuget" />
@@ -41,7 +40,7 @@
         </PropertyGroup>
 
         <RemoveDir Directories="$(DirectoriesToRemove)" />
-        <Exec Command="dotnet store @(StoreArgs, ' ') > build.log" StandardOutputImportance="low" />
+        <Exec Command="dotnet store @(StoreArgs, ' ')" StandardOutputImportance="low" />
 
         <ItemGroup>
             <Content Include="$(OutputPath)layer/x64/net5.0/artifact.xml" />

--- a/src/Layer/Layer.csproj
+++ b/src/Layer/Layer.csproj
@@ -20,10 +20,15 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="../Encryption/Encryption.csproj" />
         <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.4.2" PrivateAssets="all" />
     </ItemGroup>
 
-    <Target Name="CreateStore" DependsOnTargets="GetBuildVersion">
+    <Target Name="CreateStore" DependsOnTargets="GetBuildVersion;ResolvePackageAssets">
+        <PropertyGroup>
+            <AWSSDKCoreVersion Condition="%(RuntimeCopyLocalItems.NuGetPackageId) == 'AWSSDK.Core'">%(RuntimeCopyLocalItems.NuGetPackageVersion)</AWSSDKCoreVersion>
+        </PropertyGroup>
+
         <ItemGroup>
             <StoreArgs Include="--manifest $(MSBuildThisFileDirectory)/Manifest/Manifest.csproj" />
             <StoreArgs Include="--runtime linux-x64" />
@@ -31,8 +36,10 @@
             <StoreArgs Include="--skip-optimization" Condition="!$([MSBuild]::IsOsPlatform('linux'))" />
             <StoreArgs Include="/p:Configuration=$(Configuration)" />
             <StoreArgs Include="/p:LambdajectionVersion=$(PackageVersion)" />
+            <StoreArgs Include="/p:AWSSDKCoreVersion=$(AWSSDKCoreVersion)" />
         </ItemGroup>
 
+        <Message Importance="High" Text="Version: @(TransitiveReferences)" />
         <MakeDir Directories="$(MSBuildThisFileDirectory)Manifest/.nuget" />
 
         <PropertyGroup>

--- a/src/Layer/Layer.csproj
+++ b/src/Layer/Layer.csproj
@@ -20,15 +20,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../Encryption/Encryption.csproj" />
         <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.4.2" PrivateAssets="all" />
     </ItemGroup>
 
     <Target Name="CreateStore" DependsOnTargets="GetBuildVersion;ResolvePackageAssets">
-        <PropertyGroup>
-            <AWSSDKCoreVersion Condition="%(RuntimeCopyLocalItems.NuGetPackageId) == 'AWSSDK.Core'">%(RuntimeCopyLocalItems.NuGetPackageVersion)</AWSSDKCoreVersion>
-        </PropertyGroup>
-
         <ItemGroup>
             <StoreArgs Include="--manifest $(MSBuildThisFileDirectory)/Manifest/Manifest.csproj" />
             <StoreArgs Include="--runtime linux-x64" />
@@ -36,10 +31,8 @@
             <StoreArgs Include="--skip-optimization" Condition="!$([MSBuild]::IsOsPlatform('linux'))" />
             <StoreArgs Include="/p:Configuration=$(Configuration)" />
             <StoreArgs Include="/p:LambdajectionVersion=$(PackageVersion)" />
-            <StoreArgs Include="/p:AWSSDKCoreVersion=$(AWSSDKCoreVersion)" />
         </ItemGroup>
 
-        <Message Importance="High" Text="Version: @(TransitiveReferences)" />
         <MakeDir Directories="$(MSBuildThisFileDirectory)Manifest/.nuget" />
 
         <PropertyGroup>

--- a/src/Layer/Manifest/Manifest.csproj
+++ b/src/Layer/Manifest/Manifest.csproj
@@ -7,6 +7,7 @@
         <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
         <RestoreAdditionalProjectSources>$(PackageOutputPath);$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
         <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+        <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     </PropertyGroup>
 
     <ItemGroup>
@@ -19,10 +20,12 @@
          its dependency graph is generated without it included.
          Therefore, for ReadyToRun to do its thing, we have to copy the aws sdk core assembly and its dependencies
          into the directory where the lambdajection.core assembly is located. -->
-    <Target Name="PrepareForReadyToRun" AfterTargets="ResolvePackageAssets">
+    <Target Name="PrepareForReadyToRun" AfterTargets="Restore">
         <ItemGroup>
-            <AWSSDKCoreReference Include="@(RuntimeCopyLocalItems)" Condition="%(NuGetPackageId) == 'AWSSDK.Core'" />
+            <AWSSDKCoreReference Include="$(MSBuildThisFileDirectory)/.nuget/awssdk.core/*/lib/netcoreapp3.1/AWSSDK.Core.dll" />
         </ItemGroup>
+
+        <WriteLinesToFile Lines="@(References)" File="/tmp/testref" />
 
         <Copy
             SourceFiles="@(AWSSDKCoreReference)"

--- a/src/Layer/Manifest/Manifest.csproj
+++ b/src/Layer/Manifest/Manifest.csproj
@@ -7,13 +7,10 @@
         <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
         <RestoreAdditionalProjectSources>$(PackageOutputPath);$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
         <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
-        <AWSSDKCoreVersion>3.5.2.4</AWSSDKCoreVersion>
-        <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.Core" Version="$(AWSSDKCoreVersion)" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
         <PackageReference Include="Lambdajection.Core" Version="$(LambdajectionVersion)" />
         <PackageReference Include="Lambdajection.Encryption" Version="$(LambdajectionVersion)" />
     </ItemGroup>
@@ -24,12 +21,8 @@
          into the directory where the lambdajection.core assembly is located. -->
     <Target Name="PrepareForReadyToRun" AfterTargets="Restore" Condition="$([MSBuild]::IsOsPlatform('linux'))">
         <Copy
-            SourceFiles="$(MSBuildThisFileDirectory).nuget/awssdk.core/$(AWSSDKCoreVersion)/lib/netstandard2.0/AWSSDK.Core.dll"
+            SourceFiles="$(MSBuildThisFileDirectory).nuget/awssdk.core/$(AWSSDKCoreVersion)/lib/netcoreapp3.1/AWSSDK.Core.dll"
             DestinationFiles="$(MSBuildThisFileDirectory).nuget/lambdajection.core/$(LambdajectionVersion)/lib/net5.0/AWSSDK.Core.dll"
-        />
-        <Copy
-            SourceFiles="$(MSBuildThisFileDirectory).nuget/microsoft.bcl.asyncinterfaces/$(MicrosoftBclAsyncInterfacesVersion)/lib/netstandard2.0/Microsoft.Bcl.AsyncInterfaces.dll"
-            DestinationFiles="$(MSBuildThisFileDirectory).nuget/lambdajection.core/$(LambdajectionVersion)/lib/net5.0/Microsoft.Bcl.AsyncInterfaces.dll"
         />
     </Target>
 </Project>

--- a/src/Layer/Manifest/Manifest.csproj
+++ b/src/Layer/Manifest/Manifest.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="$(AWSSDKCoreVersion)" />
         <PackageReference Include="Lambdajection.Core" Version="$(LambdajectionVersion)" />
         <PackageReference Include="Lambdajection.Encryption" Version="$(LambdajectionVersion)" />
+        <PackageReference Include="Lambdajection.CustomResource" Version="$(LambdajectionVersion)" />
     </ItemGroup>
 
     <!-- Because AWSSDK.Core is marked as PrivateAssets="all" in Lambdajection.Core, 
@@ -20,6 +20,10 @@
          Therefore, for ReadyToRun to do its thing, we have to copy the aws sdk core assembly and its dependencies
          into the directory where the lambdajection.core assembly is located. -->
     <Target Name="PrepareForReadyToRun" AfterTargets="Restore" Condition="$([MSBuild]::IsOsPlatform('linux'))">
+        <PropertyGroup>
+            <AWSSDKCoreVersion Condition="%(RuntimeCopyLocalItems.NuGetPackageId) == 'AWSSDK.Core'">%(RuntimeCopyLocalItems.NuGetPackageVersion)</AWSSDKCoreVersion>
+        </PropertyGroup>
+
         <Copy
             SourceFiles="$(MSBuildThisFileDirectory).nuget/awssdk.core/$(AWSSDKCoreVersion)/lib/netcoreapp3.1/AWSSDK.Core.dll"
             DestinationFiles="$(MSBuildThisFileDirectory).nuget/lambdajection.core/$(LambdajectionVersion)/lib/net5.0/AWSSDK.Core.dll"

--- a/src/Layer/Manifest/Manifest.csproj
+++ b/src/Layer/Manifest/Manifest.csproj
@@ -19,13 +19,13 @@
          its dependency graph is generated without it included.
          Therefore, for ReadyToRun to do its thing, we have to copy the aws sdk core assembly and its dependencies
          into the directory where the lambdajection.core assembly is located. -->
-    <Target Name="PrepareForReadyToRun" AfterTargets="Restore" Condition="$([MSBuild]::IsOsPlatform('linux'))">
-        <PropertyGroup>
-            <AWSSDKCoreVersion Condition="%(RuntimeCopyLocalItems.NuGetPackageId) == 'AWSSDK.Core'">%(RuntimeCopyLocalItems.NuGetPackageVersion)</AWSSDKCoreVersion>
-        </PropertyGroup>
+    <Target Name="PrepareForReadyToRun" AfterTargets="ResolvePackageAssets">
+        <ItemGroup>
+            <AWSSDKCoreReference Include="@(RuntimeCopyLocalItems)" Condition="%(NuGetPackageId) == 'AWSSDK.Core'" />
+        </ItemGroup>
 
         <Copy
-            SourceFiles="$(MSBuildThisFileDirectory).nuget/awssdk.core/$(AWSSDKCoreVersion)/lib/netcoreapp3.1/AWSSDK.Core.dll"
+            SourceFiles="@(AWSSDKCoreReference)"
             DestinationFiles="$(MSBuildThisFileDirectory).nuget/lambdajection.core/$(LambdajectionVersion)/lib/net5.0/AWSSDK.Core.dll"
         />
     </Target>

--- a/src/Layer/Manifest/Manifest.csproj
+++ b/src/Layer/Manifest/Manifest.csproj
@@ -25,8 +25,6 @@
             <AWSSDKCoreReference Include="$(MSBuildThisFileDirectory)/.nuget/awssdk.core/*/lib/netcoreapp3.1/AWSSDK.Core.dll" />
         </ItemGroup>
 
-        <WriteLinesToFile Lines="@(References)" File="/tmp/testref" />
-
         <Copy
             SourceFiles="@(AWSSDKCoreReference)"
             DestinationFiles="$(MSBuildThisFileDirectory).nuget/lambdajection.core/$(LambdajectionVersion)/lib/net5.0/AWSSDK.Core.dll"

--- a/src/Layer/packages.lock.json
+++ b/src/Layer/packages.lock.json
@@ -39,6 +39,19 @@
           "StyleCop.Analyzers.Unstable": "1.2.0.321"
         }
       },
+      "AWSSDK.Core": {
+        "type": "Transitive",
+        "resolved": "3.5.1.57",
+        "contentHash": "ejhDvIToxqfxaNAVGiSJUtXemmoDzNZ9mVa8e9ogtqhyWrGXVY+dAOmAYwPYqxDzsdQXsuPgVwA3Y8DmhkXufA=="
+      },
+      "AWSSDK.KeyManagementService": {
+        "type": "Transitive",
+        "resolved": "3.5.1.6",
+        "contentHash": "gvaIcHeuMa8ulHbHuaGAg+cUygwIIEVRUk5cGWfSQlZzbIzBTS578XXkIJxGUf5ZngwMG8sqxnPTOvkcC6ZzcQ==",
+        "dependencies": {
+          "AWSSDK.Core": "[3.5.1.57, 3.6.0)"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -53,6 +66,12 @@
         "type": "Transitive",
         "resolved": "1.2.0.321",
         "contentHash": "CLL1cwvzGyXsCDzHQuAV3STrkIfTXqlS/vnxJTlSiRmmFjnTnoNVIZWwv738/hWxoh8MjPyHlp7eLossZIB5kg=="
+      },
+      "Lambdajection.Encryption": {
+        "type": "Project",
+        "dependencies": {
+          "AWSSDK.KeyManagementService": "3.5.1.6"
+        }
       }
     }
   }


### PR DESCRIPTION
This fixes it so that the AWSSDK.Core version is automatically detected for the Layer artifacts.xml