### PR TITLE
Dependency Simplifications

### DIFF
--- a/.github/releases/v0.7.0-beta2.md
+++ b/.github/releases/v0.7.0-beta2.md
@@ -1,6 +1,7 @@
 Updates for Contributors:
  
 - Dependency updates are now automated via Nukeeper
+- AWSSDK.Core is no longer a direct dependency of Lambdajection.Generator, but it will still get added to the nuget package so it can be loaded during generation if needed.
 
 Dependency updates:
 

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Core/Core.csproj" SetTargetFramework="TargetFramework=netstandard2.1" PrivateAssets="all" />
-    <ProjectReference Include="../Attributes/Attributes.csproj" PrivateAssets="all" />
-    <ProjectReference Include="../Encryption/Encryption.csproj" PrivateAssets="all" />
+    <ProjectReference Include="../Core/Core.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
+    <ProjectReference Include="../Attributes/Attributes.csproj" />
+    <ProjectReference Include="../Encryption/Encryption.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -12,33 +12,28 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Includes the compile-time generator used to generate code needed for Dependency Injection-enabled AWS Lambdas.</PackageDescription>
-    <BeforePack>IncludeBuildOutputAsAnalyzer</BeforePack>
+    <BeforePack>IncludeExtraPackItems</BeforePack>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- AWSSDK.Core here for getting path to package, needed for loading Lambdajection.Core types -->
-    <PackageReference Include="AWSSDK.Core" Version="3.5.2.7" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Core/Core.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
-    <ProjectReference Include="../Attributes/Attributes.csproj" />
-    <ProjectReference Include="../Encryption/Encryption.csproj" />
+    <ProjectReference Include="../Core/Core.csproj" SetTargetFramework="TargetFramework=netstandard2.1" PrivateAssets="all" />
+    <ProjectReference Include="../Attributes/Attributes.csproj" PrivateAssets="all" />
+    <ProjectReference Include="../Encryption/Encryption.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Lambdajection.Tests" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="build/**" Pack="true" PackagePath="build/" />
-    <None Include="$(PkgAWSSDK_Core)/lib/netstandard2.0/AWSSDK.Core.dll" CopyToOutputDirectory="always" />
-  </ItemGroup>
-
-  <Target Name="IncludeBuildOutputAsAnalyzer">
+  <Target Name="IncludeExtraPackItems">
     <ItemGroup>
+      <None Include="build/**" Pack="true" PackagePath="build/" />
+      <None Include="$(RestorePackagesPath)/awssdk.core/*/lib/netstandard2.0/AWSSDK.Core.dll" Pack="true" PackagePath="analyzers/dotnet/cs/AWSSDK.Core.dll" Visible="false" />
       <None Include="$(OutputPath)/**" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>

--- a/src/Generator/packages.lock.json
+++ b/src/Generator/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETStandard,Version=v2.1": {
-      "AWSSDK.Core": {
-        "type": "Direct",
-        "requested": "[3.5.2.7, )",
-        "resolved": "3.5.2.7",
-        "contentHash": "B4ouBMXvfNmLHxFhI/L5u4SdqeISiGT3b6+rL7renDVC1YzMM1fl6Vlp2mqzTpJm2t+FuQB6gBFdlM64GnNSyg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
-        }
-      },
       "Microsoft.CodeAnalysis": {
         "type": "Direct",
         "requested": "[3.8.0, )",
@@ -68,6 +59,14 @@
         "type": "Transitive",
         "resolved": "1.2.0",
         "contentHash": "goaq1LaH1UJB18BNG/Apxmn0P7dAlLWFbxU2nKxK+M4lH2KJaZDbtlP2gFEAJ+aENOMBHthaLPEtk3944J2OOg=="
+      },
+      "AWSSDK.Core": {
+        "type": "Transitive",
+        "resolved": "3.5.2.7",
+        "contentHash": "B4ouBMXvfNmLHxFhI/L5u4SdqeISiGT3b6+rL7renDVC1YzMM1fl6Vlp2mqzTpJm2t+FuQB6gBFdlM64GnNSyg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
+        }
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",

--- a/src/Layer/Layer.csproj
+++ b/src/Layer/Layer.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
         <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.4.2" PrivateAssets="all" />
+        <ProjectReference Include="../Generator/Generator.csproj" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <Target Name="CreateStore" DependsOnTargets="GetBuildVersion;ResolvePackageAssets">

--- a/src/Metapackage/packages.lock.json
+++ b/src/Metapackage/packages.lock.json
@@ -38,22 +38,6 @@
         "resolved": "1.2.0",
         "contentHash": "goaq1LaH1UJB18BNG/Apxmn0P7dAlLWFbxU2nKxK+M4lH2KJaZDbtlP2gFEAJ+aENOMBHthaLPEtk3944J2OOg=="
       },
-      "AWSSDK.Core": {
-        "type": "Transitive",
-        "resolved": "3.5.2.7",
-        "contentHash": "B4ouBMXvfNmLHxFhI/L5u4SdqeISiGT3b6+rL7renDVC1YzMM1fl6Vlp2mqzTpJm2t+FuQB6gBFdlM64GnNSyg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
-        }
-      },
-      "AWSSDK.KeyManagementService": {
-        "type": "Transitive",
-        "resolved": "3.5.2.8",
-        "contentHash": "6BCLnaBaB2WTMmQlOotIC0vkS8YVVkGA/8uuHnIZfC1xllweDRgXsjxo3jehSmKBiEzZu72RaSzuT5yRHWO/dw==",
-        "dependencies": {
-          "AWSSDK.Core": "[3.5.2.7, 3.6.0)"
-        }
-      },
       "Humanizer.Core": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -1349,19 +1333,9 @@
           "Microsoft.Extensions.Logging.Console": "5.0.0"
         }
       },
-      "Lambdajection.Encryption": {
-        "type": "Project",
-        "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.2.8"
-        }
-      },
       "Lambdajection.Generator": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.Core": "3.5.2.7",
-          "Lambdajection.Attributes": "1.0.0",
-          "Lambdajection.Core": "1.0.0",
-          "Lambdajection.Encryption": "1.0.0",
           "Microsoft.CodeAnalysis": "3.8.0",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.8.0"
         }

--- a/src/Metapackage/packages.lock.json
+++ b/src/Metapackage/packages.lock.json
@@ -38,6 +38,22 @@
         "resolved": "1.2.0",
         "contentHash": "goaq1LaH1UJB18BNG/Apxmn0P7dAlLWFbxU2nKxK+M4lH2KJaZDbtlP2gFEAJ+aENOMBHthaLPEtk3944J2OOg=="
       },
+      "AWSSDK.Core": {
+        "type": "Transitive",
+        "resolved": "3.5.2.7",
+        "contentHash": "B4ouBMXvfNmLHxFhI/L5u4SdqeISiGT3b6+rL7renDVC1YzMM1fl6Vlp2mqzTpJm2t+FuQB6gBFdlM64GnNSyg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.0"
+        }
+      },
+      "AWSSDK.KeyManagementService": {
+        "type": "Transitive",
+        "resolved": "3.5.2.8",
+        "contentHash": "6BCLnaBaB2WTMmQlOotIC0vkS8YVVkGA/8uuHnIZfC1xllweDRgXsjxo3jehSmKBiEzZu72RaSzuT5yRHWO/dw==",
+        "dependencies": {
+          "AWSSDK.Core": "[3.5.2.7, 3.6.0)"
+        }
+      },
       "Humanizer.Core": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -1333,9 +1349,18 @@
           "Microsoft.Extensions.Logging.Console": "5.0.0"
         }
       },
+      "Lambdajection.Encryption": {
+        "type": "Project",
+        "dependencies": {
+          "AWSSDK.KeyManagementService": "3.5.2.8"
+        }
+      },
       "Lambdajection.Generator": {
         "type": "Project",
         "dependencies": {
+          "Lambdajection.Attributes": "1.0.0",
+          "Lambdajection.Core": "1.0.0",
+          "Lambdajection.Encryption": "1.0.0",
           "Microsoft.CodeAnalysis": "3.8.0",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.8.0"
         }

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -1575,10 +1575,6 @@
       "Lambdajection.Generator": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.Core": "3.5.2.7",
-          "Lambdajection.Attributes": "1.0.0",
-          "Lambdajection.Core": "1.0.0",
-          "Lambdajection.Encryption": "1.0.0",
           "Microsoft.CodeAnalysis": "3.8.0",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.8.0"
         }

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -1575,6 +1575,9 @@
       "Lambdajection.Generator": {
         "type": "Project",
         "dependencies": {
+          "Lambdajection.Attributes": "1.0.0",
+          "Lambdajection.Core": "1.0.0",
+          "Lambdajection.Encryption": "1.0.0",
           "Microsoft.CodeAnalysis": "3.8.0",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.8.0"
         }


### PR DESCRIPTION
This simplifies the Generator's dependency tree.  AWSSDK.Core is no longer a direct dependency, but may be loaded during runtime if needed.  