### PR TITLE
LAMBJ-113 Remove Unused CodeQL Step

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
 
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
 


### PR DESCRIPTION
This removes an unused CodeQL step (checking out HEAD^2) - we are no longer running CodeQL on pull requests so this step can be removed.