### PR TITLE
LAMBJ-118 Dont Write Null PhysicalResourceIds

### DIFF
--- a/.github/releases/v0.7.0-beta2.md
+++ b/.github/releases/v0.7.0-beta2.md
@@ -1,3 +1,7 @@
+Bug Fixes:
+
+- Fixes an issue where error messages were being suppressed by a different message ('Invalid PhysicalResourceId') after responding to CloudFormation.
+
 Updates for Contributors:
  
 - Dependency updates are now automated via Nukeeper

--- a/src/Core/DefaultHttpClient.cs
+++ b/src/Core/DefaultHttpClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +11,13 @@ namespace Lambdajection.Core
     /// <inheritdoc />
     public class DefaultHttpClient : IHttpClient, IDisposable
     {
+        private readonly JsonSerializerOptions options = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
         private HttpClient httpClient = new();
+
         private bool disposed;
 
         /// <inheritdoc />
@@ -21,7 +28,9 @@ namespace Lambdajection.Core
             CancellationToken cancellationToken = default
         )
         {
-            var jsonString = JsonSerializer.Serialize(payload);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var jsonString = JsonSerializer.Serialize(payload, options);
             var content = new StringContent(jsonString);
             content.Headers.Remove("Content-Type");
 

--- a/tests/Compilation/Tests/CustomResourcesTests.cs
+++ b/tests/Compilation/Tests/CustomResourcesTests.cs
@@ -125,6 +125,7 @@ namespace Lambdajection.Tests.Compilation
             request.StackId = stackId;
             request.RequestId = requestId;
             request.LogicalResourceId = logicalResourceId;
+            request.PhysicalResourceId = null;
 
             await handler.Run(request, context);
 
@@ -137,6 +138,9 @@ namespace Lambdajection.Tests.Compilation
 
             // Tests to make sure status is serialized to all caps
             httpRequest.Body.Should().MatchRegex("\"Status\":[ ]?\"FAILED\"");
+
+            // LAMBJ-118 Null values cause 'Invalid PhysicalResourceId' error
+            httpRequest.Body.Should().NotMatchRegex("\"PhysicalResourceId\":[ ]?null");
 
             var body = JsonSerializer.Deserialize<CustomResourceResponse<ResponseData>>(httpRequest.Body);
             body.Should().Match<CustomResourceResponse<ResponseData>>(response =>


### PR DESCRIPTION
Fixes an issue where error messages were being suppressed by a different message ('Invalid PhysicalResourceId') after responding to CloudFormation.