### PR TITLE
Fix E2E Tests

### DIFF
--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -33,7 +33,7 @@
         </Exec>
 
         <Exec
-            Command="aws lambda invoke --function-name $(LambdaName) --payload '@(_InputPayload, '')' $(_OutputFileName)"
+            Command="aws lambda invoke --function-name $(LambdaName) --cli-binary-format raw-in-base64-out --payload '@(_InputPayload, '')' $(_OutputFileName)"
             StandardOutputImportance="low"
             Condition="$(TestType) == 'InvokeLambda'"
         />


### PR DESCRIPTION
AWS CLI v2 is expecting Base64 Input by default, this sets the format to accept raw/plaintext lambda payloads.