### PR TITLE
v0.7.0-beta2 Hotfixes

### DIFF
--- a/.github/releases/v0.7.0-beta3.md
+++ b/.github/releases/v0.7.0-beta3.md
@@ -1,3 +1,4 @@
-Enhancements:
 
-- 
+Bug Fixes:
+
+- This release fixes an issue where the generator would attempt to generate validations for collection types, which would result in a stack overflow.  The validations generator no longer recurses 

--- a/.github/releases/v0.7.0-beta3.md
+++ b/.github/releases/v0.7.0-beta3.md
@@ -1,4 +1,5 @@
 
 Bug Fixes:
 
-- This release fixes an issue where the generator would attempt to generate validations for collection types, which would result in a stack overflow.  The validations generator no longer recurses 
+- Fixed an issue where the generator would attempt to generate validations for collection types, which would result in a stack overflow.  The validations generator no longer recurses into these types, or any type that lives in an assembly that starts with "System"
+- Fixed an issue where validations were being generated for private and protected properties.

--- a/src/Generator/ValidationsGenerator.cs
+++ b/src/Generator/ValidationsGenerator.cs
@@ -55,10 +55,13 @@ namespace Lambdajection.Generator
         {
             typeToValidate ??= this.typeToValidate;
 
-            var members = typeToValidate.GetMembers().OfType<IPropertySymbol>() ?? ImmutableArray<IPropertySymbol>.Empty;
-            foreach (var member in members)
+            var members = from member in typeToValidate.GetMembers().OfType<IPropertySymbol>()
+                          where member.DeclaredAccessibility == Accessibility.Public
+                          select member;
+
+            foreach (var member in members ?? ImmutableArray<IPropertySymbol>.Empty)
             {
-                if (member.Type is INamedTypeSymbol memberType && memberType.ContainingAssembly.Name != "System")
+                if (member.Type is INamedTypeSymbol memberType && !memberType.ContainingAssembly.Name.StartsWith("System"))
                 {
                     ExpressionSyntax newParentExpression = parentExpression == null
                         ? ConditionalAccessExpression(

--- a/tests/Compilation/Projects/CustomResources/ResourceProperties.cs
+++ b/tests/Compilation/Projects/CustomResources/ResourceProperties.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Lambdajection.CompilationTests.CustomResources
@@ -8,6 +9,10 @@ namespace Lambdajection.CompilationTests.CustomResources
         public string Name { get; set; }
 
         public bool ShouldFail { get; set; } = false;
+
+        // This is a test - the validations generator should not recurse into collection types
+        // (it will cause a stack overflow if it does recurse, so simply running it will suffice)
+        public List<string> ValidationsGeneratorShouldNotRecurseIntoCollections { get; set; }
 
         public string ErrorMessage { get; set; } = string.Empty;
     }


### PR DESCRIPTION
This fixes glaring issues with v0.7.0-beta2 that warrant an immediate release of beta3:

- Validations were being generated for private and protected properties
- The validation generator was recursing into collection types, causing a stack overflow