### PR TITLE
LAMBJ-131 Empty Policies

### DIFF
--- a/.github/releases/v0.8.3.md
+++ b/.github/releases/v0.8.3.md
@@ -1,0 +1,3 @@
+## Bug Fixes
+
+- Fixes an issue where templates generated for Lambdas that don't interact with an AWS API would have a role policy with 0 actions, which is not allowed in CloudFormation.

--- a/src/Generator/TemplateGeneration/Converters/GetAttTagConverter.cs
+++ b/src/Generator/TemplateGeneration/Converters/GetAttTagConverter.cs
@@ -15,7 +15,8 @@ namespace Lambdajection.Generator.TemplateGeneration
 
         public object ReadYaml(IParser parser, Type type)
         {
-            throw new NotSupportedException();
+            parser.MoveNext();
+            return new GetAttTag();
         }
 
         public void WriteYaml(IEmitter emitter, object? value, Type type)

--- a/src/Generator/TemplateGeneration/Converters/SubTagConverter.cs
+++ b/src/Generator/TemplateGeneration/Converters/SubTagConverter.cs
@@ -15,7 +15,8 @@ namespace Lambdajection.Generator.TemplateGeneration
 
         public object ReadYaml(IParser parser, Type type)
         {
-            throw new NotSupportedException();
+            parser.MoveNext();
+            return new SubTag();
         }
 
         public void WriteYaml(IEmitter emitter, object? value, Type type)

--- a/src/Generator/TemplateGeneration/Models/Role.cs
+++ b/src/Generator/TemplateGeneration/Models/Role.cs
@@ -11,7 +11,9 @@ namespace Lambdajection.Generator.TemplateGeneration
 
         public Role AddPolicy(Policy policy)
         {
-            ((PropertiesDefinition)Properties).Policies.Add(policy);
+            var props = (PropertiesDefinition)Properties;
+            props.Policies ??= new List<Policy>();
+            props.Policies.Add(policy);
             return this;
         }
 
@@ -75,7 +77,7 @@ namespace Lambdajection.Generator.TemplateGeneration
         {
             public List<string> ManagedPolicyArns { get; set; } = new List<string>();
 
-            public List<Policy> Policies { get; set; } = new List<Policy>();
+            public List<Policy>? Policies { get; set; } = null;
 
             public PolicyDocument AssumeRolePolicyDocument { get; set; }
         }

--- a/src/Generator/TemplateGeneration/TemplateGenerator.cs
+++ b/src/Generator/TemplateGeneration/TemplateGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using YamlDotNet.Serialization;
 
@@ -78,9 +79,13 @@ namespace Lambdajection.Generator.TemplateGeneration
             .AddTrustedServiceEntity("lambda.amazonaws.com")
             .AddManagedPolicy("arn:aws:iam::aws:policy/AWSLambdaExecute");
 
-            var policy = new Policy($"{lambdaInfo.ClassName}PrimaryPolicy");
-            policy.AddStatement(action: lambdaInfo.Permissions);
-            role.AddPolicy(policy);
+            if (lambdaInfo.Permissions.Any())
+            {
+                var policy = new Policy($"{lambdaInfo.ClassName}PrimaryPolicy");
+                policy.AddStatement(action: lambdaInfo.Permissions);
+                role.AddPolicy(policy);
+            }
+
             return role;
         }
 

--- a/tests/Compilation/Projects/Permissionless/Handler.cs
+++ b/tests/Compilation/Projects/Permissionless/Handler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Lambdajection.Attributes;
+using Lambdajection.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lambdajection.CompilationTests.Permissionless
+{
+    [Lambda(typeof(Startup))]
+    public partial class Handler
+    {
+        public Task<string> Handle(string request, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(string.Empty);
+        }
+    }
+}
+

--- a/tests/Compilation/Projects/Permissionless/Permissionless.csproj
+++ b/tests/Compilation/Projects/Permissionless/Permissionless.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS8019</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
+  </ItemGroup>
+</Project>

--- a/tests/Compilation/Projects/Permissionless/Startup.cs
+++ b/tests/Compilation/Projects/Permissionless/Startup.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Lambdajection.Attributes;
+using Lambdajection.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using NSubstitute;
+
+namespace Lambdajection.CompilationTests.Permissionless
+{
+    public class Startup : ILambdaStartup
+    {
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+    }
+}

--- a/tests/Compilation/Projects/compilation-projects.sln
+++ b/tests/Compilation/Projects/compilation-projects.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomResources", "CustomRe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IamPermissions", "IamPermissions\IamPermissions.csproj", "{931A04BB-E210-42C0-A8C0-829BB2B8103A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Permissionless", "Permissionless\Permissionless.csproj", "{6B319CA9-14D7-4357-936B-12AFCE401706}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -170,5 +172,17 @@ Global
 		{931A04BB-E210-42C0-A8C0-829BB2B8103A}.Release|x64.Build.0 = Release|Any CPU
 		{931A04BB-E210-42C0-A8C0-829BB2B8103A}.Release|x86.ActiveCfg = Release|Any CPU
 		{931A04BB-E210-42C0-A8C0-829BB2B8103A}.Release|x86.Build.0 = Release|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Debug|x64.Build.0 = Debug|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Debug|x86.Build.0 = Debug|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x64.ActiveCfg = Release|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x64.Build.0 = Release|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x86.ActiveCfg = Release|Any CPU
+		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/Compilation/Tests/PermissionlessTests.cs
+++ b/tests/Compilation/Tests/PermissionlessTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+using FluentAssertions;
+
+using Lambdajection.Generator.TemplateGeneration;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+
+using NUnit.Framework;
+
+using YamlDotNet.Serialization;
+
+#pragma warning disable SA1009
+namespace Lambdajection.Tests.Compilation
+{
+    [Category("Integration")]
+    public class PermissionlessTests
+    {
+        private const string ProjectPath = "Compilation/Projects/Permissionless/Permissionless.csproj";
+
+        private static readonly string TemplatePath = $"{TestMetadata.BaseOutputPath}/CompilationTestProjects/Permissionless/Debug/{TestMetadata.TargetFramework}/Handler.template.yml";
+
+        private static Project project = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            project = await MSBuildProjectExtensions.LoadProject(ProjectPath);
+        }
+
+        [Test, Auto]
+        public async Task Role_ShouldNotHaveEmptyPolicy(
+            string roleArn,
+            AssumeRoleResponse response,
+            Credentials credentials,
+            IAmazonSecurityTokenService stsClient
+        )
+        {
+            using var generation = await project.GenerateAssembly();
+            var templateText = await File.ReadAllTextAsync(TemplatePath);
+            var template = new DeserializerBuilder()
+                .WithTagMapping("!GetAtt", typeof(GetAttTag))
+                .WithTagMapping("!Sub", typeof(SubTag))
+                .WithTypeConverter(new GetAttTagConverter())
+                .WithTypeConverter(new SubTagConverter())
+                .Build()
+                .Deserialize<dynamic>(templateText.ToString());
+
+            var props = (Dictionary<object, object>)template["Resources"]["HandlerRole"]["Properties"]!;
+            props.Should().NotContainKey("Policies");
+        }
+    }
+}


### PR DESCRIPTION
- Fixes an issue where templates generated for Lambdas that don't interact with an AWS API would have a role policy with 0 actions, which is not allowed in CloudFormation.