### PR TITLE
LAMBJ-129 Don't Apply Validations to Old Resource Properties

### DIFF
--- a/.github/releases/v0.8.3.md
+++ b/.github/releases/v0.8.3.md
@@ -2,3 +2,4 @@
 
 - Fixes an issue where templates generated for Lambdas that don't interact with an AWS API would have a role policy with 0 actions, which is not allowed in CloudFormation.
 - Fixes an issue where generation would fail if the project did not have a direct reference to the AWSSDK.
+- Fixes an issue where validations were being applied to old resource properties, which would cause resource creation failures if using the validation attributes.

--- a/src/CustomResource/CustomResourceRequest.cs
+++ b/src/CustomResource/CustomResourceRequest.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Lambdajection.Framework;
+
 namespace Lambdajection.CustomResource
 {
     /// <summary>
@@ -71,6 +73,7 @@ namespace Lambdajection.CustomResource
         /// This will only be present for update requests.
         /// </summary>
         /// <value>The old resource properties for the requested custom resource.</value>
+        [NotValidated]
         public virtual TResourceProperties? OldResourceProperties { get; set; }
     }
 }

--- a/src/Framework/NotValidatedAttribute.cs
+++ b/src/Framework/NotValidatedAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Lambdajection.Framework
+{
+    /// <summary>
+    /// Attribute to annotate properties that are not validated.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class NotValidatedAttribute : Attribute
+    {
+    }
+}

--- a/src/Generator/ValidationsGenerator.cs
+++ b/src/Generator/ValidationsGenerator.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 using Lambdajection.Framework;
+using Lambdajection.Framework.Utils;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,6 +19,7 @@ namespace Lambdajection.Generator
         private const string argumentName = "input";
         private readonly INamedTypeSymbol typeToValidate;
         private readonly GenerationContext context;
+        private readonly TypeUtils typeUtils = new();
 
         public ValidationsGenerator(
             AnalyzerResults interfaceAnalyzerResults,
@@ -63,6 +65,14 @@ namespace Lambdajection.Generator
 
             foreach (var member in members ?? ImmutableArray<IPropertySymbol>.Empty)
             {
+                if (member.GetAttributes().Any(attr =>
+                    attr.AttributeClass != null &&
+                    typeUtils.IsSymbolEqualToType(attr.AttributeClass, typeof(NotValidatedAttribute))
+                ))
+                {
+                    continue;
+                }
+
                 if (member.Type is INamedTypeSymbol memberType && !memberType.ContainingAssembly.Name.StartsWith("System"))
                 {
                     ExpressionSyntax newParentExpression = parentExpression == null


### PR DESCRIPTION
Fixes an issue where validations were being applied to old resource properties, which would cause resource creation failures if using the validation attributes.