### PR TITLE
LAMBJ-123 Customizable Json Serializer Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,15 @@ Community contribution/pull requests are welcome and encouraged! See the [contri
 - [4. Usage](#4-usage)
   - [4.1. Lambda Handler](#41-lambda-handler)
   - [4.2. Request Validation Attributes](#42-request-validation-attributes)
-  - [4.3. Serialization](#43-serialization)
-  - [4.4. Startup Class](#44-startup-class)
-  - [4.5. Customizing Configuration](#45-customizing-configuration)
-  - [4.6. Adding Options](#46-adding-options)
-  - [4.7. Initialization Services](#47-initialization-services)
-  - [4.8. Disposers](#48-disposers)
-  - [4.9. Handler Scheme](#49-handler-scheme)
-  - [4.10. Lambda-Backed Custom Resource Providers](#410-lambda-backed-custom-resource-providers)
-  - [4.11. Custom Runtimes](#411-custom-runtimes)
-  - [4.12. Lambda Layer](#412-lambda-layer)
+  - [4.3. Startup Class](#43-startup-class)
+  - [4.4. Customizing Configuration](#44-customizing-configuration)
+  - [4.5. Adding Options](#45-adding-options)
+  - [4.6. Initialization Services](#46-initialization-services)
+  - [4.7. Disposers](#47-disposers)
+  - [4.8. Handler Scheme](#48-handler-scheme)
+  - [4.9. Lambda-Backed Custom Resource Providers](#49-lambda-backed-custom-resource-providers)
+  - [4.10. Custom Runtimes](#410-custom-runtimes)
+  - [4.11. Lambda Layer](#411-lambda-layer)
 - [5. Examples](#5-examples)
 - [6. Acknowledgments](#6-acknowledgments)
 - [7. Donations](#7-donations)
@@ -172,21 +171,8 @@ class Request
 }
 ```
 
-### 4.3. Serialization
 
-If your Lambda targets the `netcoreapp3.1` or `net5.0` frameworks, then by default, the serializer is set to  `DefaultLambdaJsonSerializer` from the `Amazon.Lambda.Serialization.SystemTextJson` package.  With any TFM, you may specify the serializer you want to use by setting the Lambda attribute's `Serializer` argument:
-
-```cs
-[Lambda(typeof(Startup), Serializer = typeof(Serializer))]
-public partial class Lambda
-{
-    ...
-```
-
-See a [full example of serializer customization](./examples/CustomSerializer/README.md). 
-
-
-### 4.4. Startup Class
+### 4.3. Startup Class
 
 The startup class configures services that are injected into the Lambda's IoC container / service collection.
 
@@ -232,7 +218,7 @@ namespace Your.Namespace
 }
 ```
 
-### 4.5. Customizing Configuration
+### 4.4. Customizing Configuration
 
 By default, configuration is environment variables-based. If you would like to use a file-based or other configuration scheme, you may supply a custom configuration factory to the Lambda attribute:
 
@@ -268,7 +254,7 @@ namespace Your.Namespace
 
 See the [full example here](./examples/CustomConfiguration/README.md).
 
-### 4.6. Adding Options
+### 4.5. Adding Options
 
 You can add an options section by defining a class for that section, and annotating it with the [LambdaOptions attribute](src/Attributes/LambdaOptionsAttribute.cs). If any options are in encrypted form, add the [Encrypted attribute](src/Encryption/EncryptedAttribute.cs) to that property. When the options are requested, the [IDecryptionService](src/Encryption/IDecryptionService.cs) singleton in the container will be used to decrypt those properties. The [default decryption service](src/Encryption/DefaultDecryptionService.cs) uses KMS to decrypt values.
 
@@ -293,15 +279,15 @@ namespace Your.Namespace
 }
 ```
 
-### 4.7. Initialization Services
+### 4.6. Initialization Services
 
 Initialization services can be used to initialize data or perform some task before the lambda is run.  Initialization services should implement [ILambdaInitializationService](src/Core/ILambdaInitializationService.cs) and be injected into the container as singletons at startup.
 
-### 4.8. Disposers
+### 4.7. Disposers
 
 Disposers can be used to cleanup unmanaged resources, such as open file-handles and network connections. Lambdajection supports Lambdas that implement either [IDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable), [IAsyncDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable) or both.  If you implement both, DisposeAsync will be preferred.
 
-### 4.9. Handler Scheme
+### 4.8. Handler Scheme
 
 When configuring your lambda on AWS, the method name you'll want to use will be `Run` (NOT `Handle`). For context, `Run` is a static method generated on your class during compilation.  It takes care of setting up the IoC container, if it hasn't been setup already.
 
@@ -314,7 +300,7 @@ Your.Assembly.Name::Your.Namespace.YourLambda::Run
 You can customize the name of the "Run" method via the
 RunnerMethod property of `LambdaAttribute`.
 
-### 4.10. Lambda-Backed Custom Resource Providers
+### 4.9. Lambda-Backed Custom Resource Providers
 Lambdajection also allows you to write lambda-backed custom resource providers.  Just write create, update and delete methods and Lambdajection will take care of deciding which one gets called + respond to CloudFormation.
 
 Just use the [Custom Resource Provider Attribute](./src/Attributes/CustomResourceProviderAttribute.cs):
@@ -366,7 +352,7 @@ namespace Your.Namespace
 
 See also the [custom resource example](./examples/CustomResource).
 
-### 4.11. Custom Runtimes
+### 4.10. Custom Runtimes
 
 Lambdajection can be used with custom runtimes starting in v0.5.0-beta2, that way you can use a newer version of .NET as soon as it comes out, even if it is not an LTS release.  
 
@@ -392,7 +378,7 @@ You may also optionally set the `SelfContained` property:
 
 See an example of a [non-self contained lambda using a custom runtime here](./examples/CustomRuntime). (Example documentation coming soon).  Note that the example is using [a Lambda Layer we deployed with a custom bootstrap file.](https://github.com/cythral/dotnet-lambda-layer)
 
-### 4.12. Lambda Layer
+### 4.11. Lambda Layer
 
 You can use a Lambda Layer containing Lambdajection and all of its dependencies to cut down on package sizes. The layer will be available on the serverless application repository.  Once deployed, you can use it on functions that use the Lambdajection.Runtime package on custom runtimes containing .NET 5.
 

--- a/src/Core/DefaultLambdaHost.cs
+++ b/src/Core/DefaultLambdaHost.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,7 +36,7 @@ namespace Lambdajection.Core
             CancellationToken cancellationToken = default
         )
         {
-            var parameter = await JsonSerializer.DeserializeAsync<TLambdaParameter>(inputStream, cancellationToken: cancellationToken);
+            var parameter = await Serializer.Deserialize<TLambdaParameter>(inputStream, cancellationToken);
             Lambda.Validate(parameter!);
             return await Lambda.Handle(parameter!, cancellationToken);
         }

--- a/src/Core/LambdaHostBuilder.cs
+++ b/src/Core/LambdaHostBuilder.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Text.Json;
 
 using Amazon.Lambda.Core;
+
+using Lambdajection.Core.Serialization;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
+using JsonSerializer = Lambdajection.Core.Serialization.JsonSerializer;
 
 namespace Lambdajection.Core
 {
@@ -78,11 +83,17 @@ namespace Lambdajection.Core
         {
             return new ServiceCollection()
             .AddSingleton<IConfiguration>(configuration)
+            .AddSingleton<ISerializer, JsonSerializer>()
             .AddSingleton<ILambdaStartup, TLambdaStartup>()
             .AddSingleton<ILambdaConfigurator, TLambdaConfigurator>()
             .AddSingleton<IHttpClient, DefaultHttpClient>()
             .AddScoped<TLambda>()
             .AddScoped<LambdaScope>()
+            .AddSingleton(provider =>
+            {
+                var options = provider.GetService<JsonSerializerOptions>() ?? new JsonSerializerOptions();
+                return new JsonSerializerSettings(options);
+            })
             .AddScoped(provider =>
             {
                 var scope = provider.GetRequiredService<LambdaScope>();

--- a/src/Core/Serialization/ISerializer.cs
+++ b/src/Core/Serialization/ISerializer.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lambdajection.Core.Serialization
+{
+    /// <summary>
+    /// Describes an object that serializes and deserializes objects between formats.
+    /// </summary>
+    public interface ISerializer
+    {
+        /// <summary>
+        /// Serialize an object to a stream.
+        /// </summary>
+        /// <typeparam name="TSerializableType">The type of the object to serialize.</typeparam>
+        /// <param name="stream">The stream to write data to.</param>
+        /// <param name="serializable">The object to serialize.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>A stream containing the serialized representation of <paramref name="serializable" />.</returns>
+        Task Serialize<TSerializableType>(Stream stream, TSerializableType serializable, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deserialize a stream to an object of type <typeparamref name="TResultType" />.
+        /// </summary>
+        /// <typeparam name="TResultType">The type to deserialize to.</typeparam>
+        /// <param name="input">The stream input to deserialize.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The deserialized representation of the given stream.</returns>
+        ValueTask<TResultType?> Deserialize<TResultType>(Stream input, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deserialize a stream to an object of type <typeparamref name="TResultType" />.
+        /// </summary>
+        /// <typeparam name="TResultType">The type to deserialize to.</typeparam>
+        /// <param name="input">The input to deserialize.</param>
+        /// <returns>The deserialized representation of the given stream.</returns>
+        TResultType? Deserialize<TResultType>(string input);
+    }
+}

--- a/src/Core/Serialization/JsonSerializer.cs
+++ b/src/Core/Serialization/JsonSerializer.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SystemTextJsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace Lambdajection.Core.Serialization
+{
+    /// <summary>
+    /// Serializer that serializes to/from JSON.
+    /// </summary>
+    public class JsonSerializer : ISerializer
+    {
+        private readonly JsonSerializerOptions options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializer" /> class.
+        /// </summary>
+        /// <param name="settings">Options to pass to the <see cref="System.Text.Json.JsonSerializer" />'s methods.</param>
+        /// <param name="converters">Converters to add to the serializer options.</param>
+        public JsonSerializer(
+            JsonSerializerSettings settings,
+            IEnumerable<JsonConverter> converters
+        )
+        {
+            options = settings.Options;
+
+            foreach (var converter in converters)
+            {
+                options.Converters.Add(converter);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task Serialize<TSerializableType>(Stream stream, TSerializableType serializable, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await SystemTextJsonSerializer.SerializeAsync(stream, serializable, options, cancellationToken);
+            stream.Position = 0;
+        }
+
+        /// <inheritdoc />
+        public TResultType? Deserialize<TResultType>(string input)
+        {
+            return SystemTextJsonSerializer.Deserialize<TResultType>(input, options);
+        }
+
+        /// <inheritdoc />
+        public ValueTask<TResultType?> Deserialize<TResultType>(Stream deserializable, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return SystemTextJsonSerializer.DeserializeAsync<TResultType>(deserializable, options, cancellationToken);
+        }
+    }
+}

--- a/src/Core/Serialization/JsonSerializerSettings.cs
+++ b/src/Core/Serialization/JsonSerializerSettings.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+
+namespace Lambdajection.Core.Serialization
+{
+    /// <summary>
+    /// Wrapper around JsonSerializerOptions to allow a default set of options to be used
+    /// in case the user does not specify one.
+    /// </summary>
+    public class JsonSerializerSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializerSettings" /> class.
+        /// </summary>
+        /// <param name="options">The json serializer options to use.</param>
+        public JsonSerializerSettings(JsonSerializerOptions options)
+        {
+            Options = options;
+        }
+
+        /// <summary>
+        /// Gets the json serializer options.
+        /// </summary>
+        public JsonSerializerOptions Options { get; }
+    }
+}

--- a/src/CustomResource/CustomResourceLambdaHost.cs
+++ b/src/CustomResource/CustomResourceLambdaHost.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -106,7 +105,7 @@ namespace Lambdajection.CustomResource
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private async Task<CustomResourceRequest> DeserializeInput(Stream stream, CancellationToken cancellationToken)
         {
-            var input = await JsonSerializer.DeserializeAsync<CustomResourceRequest>(stream, cancellationToken: cancellationToken);
+            var input = await Serializer.Deserialize<CustomResourceRequest>(stream, cancellationToken);
             return input ?? throw new SerializationException("Request unexpectedly deserialized to null.");
         }
 
@@ -133,7 +132,7 @@ namespace Lambdajection.CustomResource
             if (request.ExtraProperties.TryGetValue(propertyName, out var element))
             {
                 var text = element.GetRawText();
-                var parameter = JsonSerializer.Deserialize<TLambdaParameter>(text);
+                var parameter = Serializer.Deserialize<TLambdaParameter>(text);
                 return parameter;
             }
 

--- a/tests/Common/AutoAttribute.cs
+++ b/tests/Common/AutoAttribute.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
@@ -17,9 +18,11 @@ internal class AutoAttribute : AutoDataAttribute
     public static IFixture Create(Action<Fixture> customize)
     {
         var fixture = new Fixture();
+        fixture.Register(() => new JsonSerializerOptions());
         fixture.Customize(new AutoNSubstituteCustomization());
         fixture.Customizations.Insert(-1, new TargetRelay());
         fixture.Customizations.Add(new TypeOmitter<IDictionary<string, JsonElement>>());
+        fixture.Customizations.Add(new TypeOmitter<JsonConverter>());
         customize(fixture);
         return fixture;
     }

--- a/tests/Compilation/Projects/Serialization/Handler.cs
+++ b/tests/Compilation/Projects/Serialization/Handler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Lambdajection.Attributes;
+using Lambdajection.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lambdajection.CompilationTests.Serialization
+{
+    [Lambda(typeof(Startup))]
+    public partial class Handler
+    {
+        public Task<string> Handle(Request request, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(request.Id);
+        }
+    }
+}
+

--- a/tests/Compilation/Projects/Serialization/Request.cs
+++ b/tests/Compilation/Projects/Serialization/Request.cs
@@ -1,0 +1,7 @@
+namespace Lambdajection.CompilationTests.Serialization
+{
+    public class Request
+    {
+        public string? Id { get; set; } = string.Empty;
+    }
+}

--- a/tests/Compilation/Projects/Serialization/Serialization.csproj
+++ b/tests/Compilation/Projects/Serialization/Serialization.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS8019</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
+  </ItemGroup>
+</Project>

--- a/tests/Compilation/Projects/Serialization/Startup.cs
+++ b/tests/Compilation/Projects/Serialization/Startup.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Lambdajection.Attributes;
+using Lambdajection.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lambdajection.CompilationTests.Serialization
+{
+    public class Startup : ILambdaStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton(new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            });
+        }
+    }
+}

--- a/tests/Compilation/Projects/compilation-projects.sln
+++ b/tests/Compilation/Projects/compilation-projects.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IamPermissions", "IamPermis
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Permissionless", "Permissionless\Permissionless.csproj", "{6B319CA9-14D7-4357-936B-12AFCE401706}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialization", "Serialization\Serialization.csproj", "{1E161549-8486-496C-9C6E-60532EAF4194}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -170,5 +172,17 @@ Global
 		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x64.Build.0 = Release|Any CPU
 		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x86.ActiveCfg = Release|Any CPU
 		{6B319CA9-14D7-4357-936B-12AFCE401706}.Release|x86.Build.0 = Release|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Debug|x86.Build.0 = Debug|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Release|x64.Build.0 = Release|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E161549-8486-496C-9C6E-60532EAF4194}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/Compilation/Tests/SerializationTests.cs
+++ b/tests/Compilation/Tests/SerializationTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+
+using NUnit.Framework;
+
+#pragma warning disable SA1009
+namespace Lambdajection.Tests.Compilation
+{
+    [Category("Integration")]
+    public class SerializationTests
+    {
+        private const string projectPath = "Compilation/Projects/Serialization/Serialization.csproj";
+
+        private static Project project = null!;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            project = await MSBuildProjectExtensions.LoadProject(projectPath);
+        }
+
+        [Test, Auto]
+        public async Task Run_ShouldReturnEmptyStringIfNotUsingCamelCase(
+            string id
+        )
+        {
+            using var generation = await project.GenerateAssembly();
+            var (assembly, _) = generation;
+            var requestType = assembly.GetType("Lambdajection.CompilationTests.Serialization.Request")!;
+            var handler = new HandlerWrapper<string>(assembly, "Lambdajection.CompilationTests.Serialization.Handler");
+            var request = (dynamic)Activator.CreateInstance(requestType)!;
+            request.Id = id;
+
+            using var inputStream = await StreamUtils.CreateJsonStream(request);
+            string result = await handler.Run(inputStream, null);
+
+            result.Should().Be(string.Empty);
+        }
+
+        [Test, Auto]
+        public async Task Run_ShouldReturnIdIfUsingCamelCase(
+            string id
+        )
+        {
+            using var generation = await project.GenerateAssembly();
+            var (assembly, _) = generation;
+            var requestType = assembly.GetType("Lambdajection.CompilationTests.Serialization.Request")!;
+            var handler = new HandlerWrapper<string>(assembly, "Lambdajection.CompilationTests.Serialization.Handler");
+            var request = (dynamic)Activator.CreateInstance(requestType)!;
+            request.Id = id;
+
+            using var inputStream = await StreamUtils.CreateJsonStream(request, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            string result = await handler.Run(inputStream, null);
+
+            result.Should().Be(id);
+        }
+    }
+}

--- a/tests/Unit/Core/LambdaHostBuilderTests.cs
+++ b/tests/Unit/Core/LambdaHostBuilderTests.cs
@@ -5,6 +5,8 @@ using AutoFixture.AutoNSubstitute;
 
 using FluentAssertions;
 
+using Lambdajection.Core.Serialization;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -116,6 +118,15 @@ namespace Lambdajection.Core.Tests
 
             var configuration = provider.GetService<TestLambda>();
             configuration.Should().NotBeNull();
+        }
+
+        [Test]
+        public void BuildServiceProviderReturnsServiceProviderWithSerializer()
+        {
+            var provider = TestLambdaHostBuilder.BuildServiceProvider();
+
+            var serializer = provider.GetService<ISerializer>();
+            serializer.Should().NotBeNull();
         }
 
         [Test, Auto]

--- a/tests/Unit/Core/Serialization/JsonSerializerTests.cs
+++ b/tests/Unit/Core/Serialization/JsonSerializerTests.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Lambdajection.Core.Serialization
+{
+    [TestFixture]
+    [Category("Unit")]
+    public class JsonSerializerTests
+    {
+        [Test, Auto]
+        public async Task Serialize_SerializesToJsonStream(
+            [Target] JsonSerializer serializer
+        )
+        {
+            var serializable = new TestObject { A = "A", B = "B" };
+            var cancellationToken = new CancellationToken(false);
+            var stream = new MemoryStream();
+            await serializer.Serialize(stream, serializable, cancellationToken);
+
+            using var reader = new StreamReader(stream);
+            var result = await reader.ReadToEndAsync();
+            result.Should().Be("{\"A\":\"A\",\"B\":\"B\"}");
+        }
+
+        [Test, Auto]
+        public void Deserialize_DeserializesToObject(
+            [Target] JsonSerializer serializer
+        )
+        {
+            var deserializable = "{\"A\":\"A\",\"B\":\"B\"}";
+            var result = serializer.Deserialize<TestObject>(deserializable);
+
+            result!.A.Should().Be("A");
+            result!.B.Should().Be("B");
+        }
+
+        [Test, Auto]
+        public async Task Deserialize_DeserializesStreamsToObjects(
+            [Target] JsonSerializer serializer
+        )
+        {
+            var deserializableBytes = Encoding.UTF8.GetBytes("{\"A\":\"A\",\"B\":\"B\"}");
+            var deserializableStream = new MemoryStream(deserializableBytes);
+            var cancellationToken = new CancellationToken(false);
+
+            var result = await serializer.Deserialize<TestObject>(deserializableStream, cancellationToken);
+
+            result!.A.Should().Be("A");
+            result!.B.Should().Be("B");
+        }
+
+        private class TestObject
+        {
+            public string A { get; set; } = string.Empty;
+
+            public string B { get; set; } = string.Empty;
+        }
+    }
+}

--- a/tests/Unit/CustomResource/CustomResourceLambdaHostTests.cs
+++ b/tests/Unit/CustomResource/CustomResourceLambdaHostTests.cs
@@ -10,6 +10,7 @@ using AutoFixture.AutoNSubstitute;
 using FluentAssertions;
 
 using Lambdajection.Core;
+using Lambdajection.Core.Serialization;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -49,10 +50,12 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldCallCreate_IfRequestTypeIsCreate(
                 ServiceCollection serviceCollection,
                 CustomResourceRequest<object> request,
+                JsonSerializer serializer,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
             )
             {
+                serviceCollection.AddSingleton<ISerializer>(serializer);
                 serviceCollection.AddSingleton(httpClient);
 
                 var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -61,6 +64,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -77,6 +81,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldCallUpdate_IfRequestTypeIsUpdate(
                 ServiceCollection serviceCollection,
                 CustomResourceRequest<object> request,
+                JsonSerializer serializer,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
             )
@@ -89,6 +94,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Update;
@@ -104,6 +110,7 @@ namespace Lambdajection.CustomResource.Tests
             [Test, Auto]
             public async Task ShouldCallCreate_IfRequestTypeIsUpdate_ButLambdaRequiresReplacement(
                 ServiceCollection serviceCollection,
+                JsonSerializer serializer,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -117,6 +124,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Update;
@@ -134,6 +142,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldCallDelete_IfRequestTypeIsDelete(
                 ServiceCollection serviceCollection,
                 CustomResourceRequest<object> request,
+                JsonSerializer serializer,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
             )
@@ -146,6 +155,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Delete;
@@ -163,6 +173,7 @@ namespace Lambdajection.CustomResource.Tests
                 ServiceCollection serviceCollection,
                 TestCustomResourceOutputData data,
                 CustomResourceRequest<object> request,
+                JsonSerializer serializer,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
             )
@@ -176,6 +187,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -198,6 +210,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondSuccessWithStackId(
                 ServiceCollection serviceCollection,
                 string stackId,
+                JsonSerializer serializer,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -211,6 +224,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -234,6 +248,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondSuccessWithRequestId(
                 ServiceCollection serviceCollection,
                 string requestId,
+                JsonSerializer serializer,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -247,6 +262,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -270,6 +286,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondSuccessWithLogicalResourceId(
                 ServiceCollection serviceCollection,
                 string logicalResourceId,
+                JsonSerializer serializer,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -283,6 +300,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -306,6 +324,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondSuccessWithPhysicalResourceId(
                 ServiceCollection serviceCollection,
                 string physicalResourceId,
+                JsonSerializer serializer,
                 TestCustomResourceOutputData data,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
@@ -322,6 +341,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -344,12 +364,14 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondFailureWithReason(
                 string reason,
                 ServiceCollection serviceCollection,
+                JsonSerializer serializer,
                 TestCustomResourceOutputData data,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
             )
             {
+                serviceCollection.AddSingleton<ISerializer>(serializer);
                 serviceCollection.AddSingleton(httpClient);
                 lambda.Create(Any<CustomResourceRequest<TestLambdaMessage>>(), Any<CancellationToken>()).Returns<TestCustomResourceOutputData>(x =>
                 {
@@ -362,6 +384,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -385,6 +408,7 @@ namespace Lambdajection.CustomResource.Tests
                 string requestId,
                 Uri responseURL,
                 TestCustomResourceOutputData data,
+                JsonSerializer serializer,
                 ServiceCollection serviceCollection,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -399,6 +423,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 var input = $@"{{ ""RequestId"": ""{requestId}"", ""ResponseURL"": ""{responseURL}"", ""RequestType"": ""Create"", ""ResourceProperties"": {{ ""Id"": 1 }} }}";
@@ -421,6 +446,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldThrowIfRequestDeserializesToNull(
                 string requestId,
                 Uri responseURL,
+                JsonSerializer serializer,
                 TestCustomResourceOutputData data,
                 ServiceCollection serviceCollection,
                 [Substitute] TestCustomResourceLambda lambda,
@@ -436,6 +462,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 var input = $@"null";
@@ -450,6 +477,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondFailureWithRequestId(
                 string requestId,
                 ServiceCollection serviceCollection,
+                JsonSerializer serializer,
                 TestCustomResourceOutputData data,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
@@ -468,6 +496,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -491,6 +520,7 @@ namespace Lambdajection.CustomResource.Tests
             public async Task ShouldRespondFailureWithStackId(
                 string stackId,
                 ServiceCollection serviceCollection,
+                JsonSerializer serializer,
                 TestCustomResourceOutputData data,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
@@ -509,6 +539,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -533,6 +564,7 @@ namespace Lambdajection.CustomResource.Tests
                 string logicalResourceId,
                 ServiceCollection serviceCollection,
                 TestCustomResourceOutputData data,
+                JsonSerializer serializer,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -550,6 +582,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;
@@ -574,6 +607,7 @@ namespace Lambdajection.CustomResource.Tests
                 string physicalResourceId,
                 ServiceCollection serviceCollection,
                 TestCustomResourceOutputData data,
+                JsonSerializer serializer,
                 CustomResourceRequest<object> request,
                 [Substitute] TestCustomResourceLambda lambda,
                 [Substitute] IHttpClient httpClient
@@ -591,6 +625,7 @@ namespace Lambdajection.CustomResource.Tests
                 {
                     lambdaHost.Lambda = lambda;
                     lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
                 });
 
                 request.RequestType = CustomResourceRequestType.Create;

--- a/tests/Utils/StreamUtils.cs
+++ b/tests/Utils/StreamUtils.cs
@@ -4,10 +4,11 @@ using System.Threading.Tasks;
 
 public class StreamUtils
 {
-    public static async Task<Stream> CreateJsonStream<TInput>(TInput input)
+    public static async Task<Stream> CreateJsonStream<TInput>(TInput input, JsonSerializerOptions? options = null)
     {
+        options ??= new JsonSerializerOptions();
         var stream = new MemoryStream();
-        await JsonSerializer.SerializeAsync(stream, input);
+        await JsonSerializer.SerializeAsync(stream, input, options);
         stream.Position = 0;
         return stream;
     }


### PR DESCRIPTION
Adding customizable Json serializer options.  Customization is done by injecting a System.Text.Json.JsonSerializerOptions into the service collection at startup.