### PR TITLE
Nullable Custom Resource ResponseURL

### DIFF
--- a/.github/releases/v0.9.0-beta4.md
+++ b/.github/releases/v0.9.0-beta4.md
@@ -1,6 +1,8 @@
 # Enhancements
 
 - CloudFormationStackEvent objects are now serializable.
+- ResponseURL is now an optional argument to custom resource requests, to allow for easier testing.  
+- The lambda output for Custom Resources is now the full response that would've been sent to CloudFormation, rather than just the output data.
 
 # Bug Fixes
 

--- a/src/CustomResource/CustomResourceLambdaHost.cs
+++ b/src/CustomResource/CustomResourceLambdaHost.cs
@@ -15,7 +15,7 @@ namespace Lambdajection.CustomResource
 {
     /// <inheritdoc />
     public sealed class CustomResourceLambdaHost<TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory>
-        : LambdaHostBase<TLambda, CustomResourceRequest<TLambdaParameter>, TLambdaOutput, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory>
+        : LambdaHostBase<TLambda, CustomResourceRequest<TLambdaParameter>, CustomResourceResponse<TLambdaOutput>, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory>
         where TLambda : class, ICustomResourceProvider<TLambdaParameter, TLambdaOutput>
         where TLambdaParameter : class
         where TLambdaOutput : class, ICustomResourceOutputData
@@ -35,13 +35,13 @@ namespace Lambdajection.CustomResource
         /// Initializes a new instance of the <see cref="CustomResourceLambdaHost{TLambda, TLambdaParameter, TLambdaOutput, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory}" /> class.
         /// </summary>
         /// <param name="build">The builder action to run on the lambda.</param>
-        internal CustomResourceLambdaHost(Action<LambdaHostBase<TLambda, CustomResourceRequest<TLambdaParameter>, TLambdaOutput, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory>> build)
+        internal CustomResourceLambdaHost(Action<LambdaHostBase<TLambda, CustomResourceRequest<TLambdaParameter>, CustomResourceResponse<TLambdaOutput>, TLambdaStartup, TLambdaConfigurator, TLambdaConfigFactory>> build)
             : base(build)
         {
         }
 
         /// <inheritdoc />
-        public override async Task<TLambdaOutput> InvokeLambda(
+        public override async Task<CustomResourceResponse<TLambdaOutput>> InvokeLambda(
             Stream inputStream,
             CancellationToken cancellationToken = default
         )
@@ -92,14 +92,17 @@ namespace Lambdajection.CustomResource
                 };
             }
 
-            await httpClient.PutJson(
-                requestUri: input.ResponseURL,
-                payload: response,
-                contentType: null,
-                cancellationToken: cancellationToken
-            );
+            if (input.ResponseURL != null)
+            {
+                await httpClient.PutJson(
+                    requestUri: input.ResponseURL,
+                    payload: response,
+                    contentType: null,
+                    cancellationToken: cancellationToken
+                );
+            }
 
-            return response.Data!;
+            return response;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/CustomResource/CustomResourceRequest.cs
+++ b/src/CustomResource/CustomResourceRequest.cs
@@ -24,7 +24,7 @@ namespace Lambdajection.CustomResource
         /// has been created/updated/deleted.
         /// </summary>
         /// <value>The response URL.</value>
-        public virtual Uri ResponseURL { get; set; } = new Uri("http://localhost");
+        public virtual Uri? ResponseURL { get; set; }
 
         /// <summary>
         /// Gets or sets the Id of the CloudFormation stack that the

--- a/tests/Unit/CustomResource/CustomResourceLambdaHostTests.cs
+++ b/tests/Unit/CustomResource/CustomResourceLambdaHostTests.cs
@@ -196,7 +196,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Success &&
                         response.Data == data
@@ -234,7 +234,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Success &&
                         response.StackId == stackId
@@ -272,7 +272,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Success &&
                         response.RequestId == requestId
@@ -310,7 +310,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Success &&
                         response.LogicalResourceId == logicalResourceId
@@ -350,13 +350,49 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Success &&
                         response.PhysicalResourceId == physicalResourceId
                     ),
                     Is((string)null!),
                     Is(cancellationToken)
+                );
+            }
+
+            [Test, Auto]
+            public async Task ShouldNotRespondSuccessIfResponseURLIsNull(
+                ServiceCollection serviceCollection,
+                string stackId,
+                JsonSerializer serializer,
+                CustomResourceRequest<object> request,
+                [Substitute] TestCustomResourceLambda lambda,
+                [Substitute] IHttpClient httpClient
+            )
+            {
+                serviceCollection.AddSingleton(httpClient);
+                request.ResponseURL = null;
+
+                var serviceProvider = serviceCollection.BuildServiceProvider();
+                var cancellationToken = new CancellationToken(false);
+                var host = new TestCustomResourceLambdaHost(lambdaHost =>
+                {
+                    lambdaHost.Lambda = lambda;
+                    lambdaHost.Scope = serviceProvider.CreateScope();
+                    lambdaHost.Serializer = serializer;
+                });
+
+                request.RequestType = CustomResourceRequestType.Create;
+                request.StackId = stackId;
+
+                using var inputStream = await StreamUtils.CreateJsonStream(request);
+                await host.InvokeLambda(inputStream, cancellationToken);
+
+                await httpClient.DidNotReceiveWithAnyArgs().PutJson(
+                    default!,
+                    default(CustomResourceResponse<TestCustomResourceOutputData>)!,
+                    default!,
+                    default!
                 );
             }
 
@@ -393,7 +429,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Failed &&
                         response.Reason == reason
@@ -506,7 +542,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Failed &&
                         response.RequestId == requestId
@@ -549,7 +585,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Failed &&
                         response.StackId == stackId
@@ -592,7 +628,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Failed &&
                         response.LogicalResourceId == logicalResourceId
@@ -635,7 +671,7 @@ namespace Lambdajection.CustomResource.Tests
                 await host.InvokeLambda(inputStream, cancellationToken);
 
                 await httpClient.Received().PutJson(
-                    Is(request.ResponseURL),
+                    Is(request.ResponseURL!),
                     Is<CustomResourceResponse<TestCustomResourceOutputData>>(response =>
                         response.Status == CustomResourceResponseStatus.Failed &&
                         response.PhysicalResourceId == physicalResourceId


### PR DESCRIPTION
- ResponseURL is now an optional argument to custom resource requests, to allow for easier testing.  
- The lambda output for Custom Resources is now the full response that would've been sent to CloudFormation, rather than just the output data