### PR TITLE
LAMBJ-148 Remove Source Topic Property

### DIFF
--- a/src/Core/Serialization/StringConverter.cs
+++ b/src/Core/Serialization/StringConverter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 
 using SystemTextJsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -53,7 +52,15 @@ namespace Lambdajection.Core.Serialization
         public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
         {
             var stringValue = SystemTextJsonSerializer.Serialize(value!, typeToConvert, options);
-            writer.WriteStringValue(Regex.Unescape(stringValue));
+
+            if (stringValue.StartsWith('\"'))
+            {
+                writer.WriteRawValue(stringValue);
+            }
+            else
+            {
+                writer.WriteStringValue(stringValue);
+            }
         }
     }
 }

--- a/src/Sns/Models/CloudFormationStackEvent.cs
+++ b/src/Sns/Models/CloudFormationStackEvent.cs
@@ -10,11 +10,6 @@ namespace Lambdajection.Sns
     public class CloudFormationStackEvent
     {
         /// <summary>
-        /// Gets or sets the source topic of the stack event.
-        /// </summary>
-        public string SourceTopic { get; set; } = string.Empty;
-
-        /// <summary>
         /// Gets or sets the id of the stack this event came from.
         /// </summary>
         public string StackId { get; set; } = string.Empty;

--- a/src/Sns/Serialization/CloudFormationStackEventConverter.cs
+++ b/src/Sns/Serialization/CloudFormationStackEventConverter.cs
@@ -29,12 +29,6 @@ namespace Lambdajection.Sns
 
                 switch (key)
                 {
-                    case nameof(CloudFormationStackEvent.SourceTopic):
-                        {
-                            result.SourceTopic = value;
-                            break;
-                        }
-
                     case nameof(CloudFormationStackEvent.StackId):
                         {
                             result.StackId = value;
@@ -118,7 +112,6 @@ namespace Lambdajection.Sns
         public override void Write(Utf8JsonWriter writer, CloudFormationStackEvent value, JsonSerializerOptions options)
         {
             var lines = string.Empty;
-            lines += $"SourceTopic='{value.SourceTopic}'\n";
             lines += $"StackId='{value.StackId}'\n";
             lines += $"Timestamp='{value.Timestamp}'\n";
             lines += $"EventId='{value.EventId}'\n";

--- a/tests/Unit/Sns/Serialization/CloudFormationStackEventConverterTests.cs
+++ b/tests/Unit/Sns/Serialization/CloudFormationStackEventConverterTests.cs
@@ -16,17 +16,6 @@ namespace Lambdajection.Sns
         public class Deserialization
         {
             [Test, Auto]
-            public void SourceTopicShouldDeserialize(
-                string sourceTopic
-            )
-            {
-                var source = $@"""SourceTopic={sourceTopic}""";
-                var result = JsonSerializer.Deserialize<CloudFormationStackEvent>(source);
-
-                result!.SourceTopic.Should().Be(sourceTopic);
-            }
-
-            [Test, Auto]
             public void StackIdShouldDeserialize(
                 string stackId
             )
@@ -179,17 +168,6 @@ namespace Lambdajection.Sns
         public class Serialization
         {
             [Test, Auto]
-            public void SourceTopicShouldSerialize(
-                CloudFormationStackEvent stackEvent
-            )
-            {
-                var result = JsonSerializer.Serialize(stackEvent).Trim('"');
-                var lines = Regex.Unescape(result).Split('\n');
-
-                lines.Should().Contain($"SourceTopic='{stackEvent.SourceTopic}'");
-            }
-
-            [Test, Auto]
             public void StackIdShouldSerialize(
                 CloudFormationStackEvent stackEvent
             )
@@ -329,6 +307,7 @@ namespace Lambdajection.Sns
             )
             {
                 var serialized = JsonSerializer.Serialize(message);
+                Console.WriteLine(serialized);
                 var deserialized = JsonSerializer.Deserialize<SnsMessage<CloudFormationStackEvent>>(serialized);
 
                 deserialized!.Message.StackId.Should().Be(message.Message.StackId);

--- a/tests/Unit/Sns/Serialization/CloudFormationStackEventConverterTests.cs
+++ b/tests/Unit/Sns/Serialization/CloudFormationStackEventConverterTests.cs
@@ -307,7 +307,6 @@ namespace Lambdajection.Sns
             )
             {
                 var serialized = JsonSerializer.Serialize(message);
-                Console.WriteLine(serialized);
                 var deserialized = JsonSerializer.Deserialize<SnsMessage<CloudFormationStackEvent>>(serialized);
 
                 deserialized!.Message.StackId.Should().Be(message.Message.StackId);


### PR DESCRIPTION
Removes the Source Topic Property as this was mistakenly carried over from
an internal Cythral project.

Also fixes serialization of strings so that unicode quotes are not wrapped around the real value.
This was specifically happening for CloudFormationStackEvents.