### PR TITLE
LAMBJ-149 Remove SNS Batching

### DIFF
--- a/tests/Compilation/Tests/SnsTests.cs
+++ b/tests/Compilation/Tests/SnsTests.cs
@@ -26,9 +26,8 @@ namespace Lambdajection.Tests.Compilation
         }
 
         [Test, Auto]
-        public async Task Run_ShouldReturnListOfAllRelevantIds(
-            string id1,
-            string id2
+        public async Task Run_ShouldReturnTheId(
+            string id
         )
         {
             static SnsRecord<CloudFormationStackEvent> CreateRecord(string id)
@@ -41,15 +40,15 @@ namespace Lambdajection.Tests.Compilation
 
             using var generation = await project.GenerateAssembly();
             var (assembly, _) = generation;
-            var handler = new HandlerWrapper<string[]>(assembly, "Lambdajection.CompilationTests.Sns.Handler");
+            var handler = new HandlerWrapper<string>(assembly, "Lambdajection.CompilationTests.Sns.Handler");
 
-            var recordArray = new[] { CreateRecord(id1), CreateRecord(id2) };
+            var recordArray = new[] { CreateRecord(id) };
             var snsEvent = new SnsEvent<CloudFormationStackEvent>(recordArray);
 
             using var inputStream = await StreamUtils.CreateJsonStream(snsEvent);
-            string[] result = (await handler.Run(inputStream, null!))!;
+            string result = (await handler.Run(inputStream, null!))!;
 
-            result.Should().BeEquivalentTo(new[] { id1, id2 });
+            result.Should().Be(id);
         }
     }
 }

--- a/tests/Unit/Sns/SnsLambdaHostTests.cs
+++ b/tests/Unit/Sns/SnsLambdaHostTests.cs
@@ -66,14 +66,13 @@ namespace Lambdajection.Sns
 
             [Test, Auto]
             public async Task ShouldCallLambdaWithEachMessage(
-                SnsRecord<TestLambdaMessage> record1,
-                SnsRecord<TestLambdaMessage> record2,
+                SnsRecord<TestLambdaMessage> record,
                 ServiceCollection serviceCollection,
                 JsonSerializer serializer,
                 [Substitute] TestSnsLambda lambda
             )
             {
-                var request = new SnsEvent<TestLambdaMessage>(new[] { record1, record2 });
+                var request = new SnsEvent<TestLambdaMessage>(new[] { record });
 
                 serviceCollection.AddSingleton<ISerializer>(serializer);
 
@@ -88,20 +87,18 @@ namespace Lambdajection.Sns
 
                 using var inputStream = await StreamUtils.CreateJsonStream(request);
                 await host.InvokeLambda(inputStream, cancellationToken);
-                await lambda.Received().Handle(Matches(record1.Sns), Is(cancellationToken));
-                await lambda.Received().Handle(Matches(record2.Sns), Is(cancellationToken));
+                await lambda.Received().Handle(Matches(record.Sns), Is(cancellationToken));
             }
 
             [Test, Auto]
-            public async Task ShouldValidateEachMessage(
-                SnsRecord<TestLambdaMessage> record1,
-                SnsRecord<TestLambdaMessage> record2,
+            public async Task ShouldValidateMessage(
+                SnsRecord<TestLambdaMessage> record,
                 ServiceCollection serviceCollection,
                 JsonSerializer serializer,
                 [Substitute] TestSnsLambda lambda
             )
             {
-                var request = new SnsEvent<TestLambdaMessage>(new[] { record1, record2 });
+                var request = new SnsEvent<TestLambdaMessage>(new[] { record });
 
                 serviceCollection.AddSingleton<ISerializer>(serializer);
 
@@ -117,8 +114,7 @@ namespace Lambdajection.Sns
                 using var inputStream = await StreamUtils.CreateJsonStream(request);
                 await host.InvokeLambda(inputStream, cancellationToken);
 
-                lambda.Received().Validate(Matches(record1.Sns));
-                lambda.Received().Validate(Matches(record2.Sns));
+                lambda.Received().Validate(Matches(record.Sns));
             }
         }
     }


### PR DESCRIPTION
Removes SNS Batching - these events will always only have 1 record so there is no need to loop through them.