### PR TITLE
Load Assemblies Into Generator AppDomain Only If Version Matches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_OSS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Set version
+        shell: bash
+        run: echo "VERSION=$(cat version.json | jq -r '.version')" >> $GITHUB_ENV
+
       - name: Download NuGets
         uses: actions/download-artifact@v2
         id: download-nugets
@@ -227,10 +237,6 @@ jobs:
             --template ${{ steps.download-layer-template.outputs.download-path }}/Layer.template.yml \
             --region us-east-1 \
             --semantic-version ${VERSION}
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - uses: ncipollo/release-action@v1
         with:

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" PrivateAssets="runtime;analyzers;contentfiles;build" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="runtime;analyzers;contentfiles;build" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" PrivateAssets="runtime;analyzers;contentfiles;build" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" PrivateAssets="runtime;analyzers;contentfiles;build" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" PrivateAssets="runtime;analyzers;contentfiles;build" />
   </ItemGroup>
 

--- a/src/Generator/Program.cs
+++ b/src/Generator/Program.cs
@@ -61,7 +61,7 @@ namespace Lambdajection.Generator
                     try
                     {
                         var assembly = Assembly.LoadFile(matchingFile);
-                        if (assembly.GetName().Version == name.Version)
+                        if (assembly.GetName().Version >= name.Version)
                         {
                             return assembly;
                         }

--- a/src/Generator/Program.cs
+++ b/src/Generator/Program.cs
@@ -60,7 +60,11 @@ namespace Lambdajection.Generator
                 {
                     try
                     {
-                        return Assembly.LoadFile(matchingFile);
+                        var assembly = Assembly.LoadFile(matchingFile);
+                        if (assembly.GetName().Version == name.Version)
+                        {
+                            return assembly;
+                        }
                     }
                     catch (Exception)
                     {

--- a/src/Generator/packages.lock.json
+++ b/src/Generator/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     ".NETStandard,Version=v2.1": {
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
       "Microsoft.CodeAnalysis": {
         "type": "Direct",
         "requested": "[4.0.1, )",
@@ -108,11 +114,6 @@
         "dependencies": {
           "NETStandard.Library": "1.6.1"
         }
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/src/Metapackage/packages.lock.json
+++ b/src/Metapackage/packages.lock.json
@@ -1542,6 +1542,7 @@
           "Lambdajection.Attributes": "1.0.0",
           "Lambdajection.Framework": "1.0.0",
           "Lambdajection.Framework.BuildTime": "1.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "Microsoft.CodeAnalysis": "4.0.1",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "4.0.1",
           "Microsoft.Extensions.Hosting": "6.0.0",

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -293,8 +293,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ=="
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -1869,6 +1869,7 @@
           "Lambdajection.Attributes": "1.0.0",
           "Lambdajection.Framework": "1.0.0",
           "Lambdajection.Framework.BuildTime": "1.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "Microsoft.CodeAnalysis": "4.0.1",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "4.0.1",
           "Microsoft.Extensions.Hosting": "6.0.0",


### PR DESCRIPTION
Whenever an assembly was loaded into the generator, the version was not being checked.  So if there were multiple versions of the same assembly, there was a chance the version was wrong (and would later cause typeloadexceptions when attempting to load types from that assembly).