### PR TITLE
LAMBJ-147 Catch & Log Exceptions

### DIFF
--- a/.github/releases/v0.10.0-beta1.md
+++ b/.github/releases/v0.10.0-beta1.md
@@ -1,0 +1,4 @@
+## Enhancements
+
+- Uncaught exceptions are now logged as critical errors.  
+- Exceptions are logged under the "Lambdajection" Log Category, which can be filtered out via ILambdaStartup.ConfigureLogging.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   "editor.formatOnType": true,
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
+  "omnisharp.enableImportCompletion": true,
   "prettier.enable": false,
   "xml.format.preserveAttributeLineBreaks": true,
   "markdown.extension.toc.levels": "2..6",

--- a/tests/Common/TestLambda.cs
+++ b/tests/Common/TestLambda.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,10 +10,12 @@ namespace Lambdajection
     {
         public object Request { get; set; } = null!;
 
+        public Action? HandleAction { get; set; } = null;
+
         public virtual Task<TestLambdaMessage> Handle(TestLambdaMessage request, CancellationToken cancellationToken = default)
         {
             Request = request;
-
+            HandleAction?.Invoke();
             return Task.FromResult<TestLambdaMessage>(null!);
         }
 


### PR DESCRIPTION
- Uncaught exceptions are now logged as critical errors.  
- Exceptions are logged under the "Lambdajection" Log Category, which can be filtered out via ILambdaStartup.ConfigureLogging.