### PR TITLE
LAMBJ-151 ARM Layer

### DIFF
--- a/.github/releases/v0.10.0-beta1.md
+++ b/.github/releases/v0.10.0-beta1.md
@@ -2,3 +2,4 @@
 
 - Uncaught exceptions are now logged as critical errors.  
 - Exceptions are logged under the "Lambdajection" Log Category, which can be filtered out via ILambdaStartup.ConfigureLogging.
+- The Lambdajection Lambda Layer now supports arm64-based lambdas.

--- a/src/Layer/Layer.csproj
+++ b/src/Layer/Layer.csproj
@@ -26,15 +26,21 @@
         <ProjectReference Include="../Attributes/Attributes.csproj" PrivateAssets="runtime" />
     </ItemGroup>
 
-    <Target Name="CreateStore" DependsOnTargets="GetBuildVersion;ResolvePackageAssets">
+    <ItemGroup>
+        <LayerArchitectures Include="arm64" />
+        <LayerArchitectures Include="x64" />
+    </ItemGroup>
+
+    <Target Name="CreateStore" DependsOnTargets="GetBuildVersion;ResolvePackageAssets" Outputs="%(LayerArchitectures.Identity)">
         <PropertyGroup>
+            <CurrentArchitecture>%(LayerArchitectures.Identity)</CurrentArchitecture>
             <ReferencePaths>@(ReferencePath, '%253B')</ReferencePaths>
         </PropertyGroup>
 
         <ItemGroup>
             <StoreArgs Include="--manifest $(MSBuildThisFileDirectory)/Manifest/Manifest.csproj" />
             <StoreArgs Include="--output $(OutputPath)/layer" />
-            <StoreArgs Include="--runtime linux-x64" />
+            <StoreArgs Include="--runtime linux-$(CurrentArchitecture)" />
             <!-- Optimized runtime package stores does not work on .NET 6 -->
             <StoreArgs Include="--skip-optimization" />
             <StoreArgs Include="/p:Configuration=$(Configuration)" />
@@ -53,7 +59,7 @@
         <Exec Command="dotnet store @(StoreArgs, ' ')" StandardOutputImportance="low" />
 
         <ItemGroup>
-            <Content Include="$(OutputPath)layer/x64/net6.0/artifact.xml" />
+            <Content Include="$(OutputPath)layer/$(CurrentArchitecture)/net6.0/artifact.xml" Condition="$(CurrentArchitecture) == 'x64'" />
         </ItemGroup>
     </Target>
 

--- a/src/Layer/Layer.template.yml
+++ b/src/Layer/Layer.template.yml
@@ -25,6 +25,9 @@ Resources:
       Description: Lambda Layer for Lambajection
       CompatibleRuntimes:
         - provided.al2
+      CompatibleArchitectures:
+        - x86_64
+        - arm64
       ContentUri: ./layer
       LicenseInfo: MIT
 

--- a/src/Layer/Manifest/Manifest.csproj
+++ b/src/Layer/Manifest/Manifest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+        <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
         <RestoreLockedMode>false</RestoreLockedMode>
         <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
         <RestoreAdditionalProjectSources>$(PackageOutputPath);$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>


### PR DESCRIPTION
The Lambdajection Lambda Layer now supports arm64-based lambdas.